### PR TITLE
Enhance python node editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ IFC Flow Map provides a graphical interface for viewing, filtering, transforming
   - 📊 **Analysis Node** - Perform analyses like clash detection
   - 👀 **Watch Node** - Monitor element values
   - ⚙️ **Parameter Node** - Define workflow parameters
+  - 🐍 **Python Script Node** - Execute custom Python code within the workflow
 - 💾 **Workflow Storage** - Save and load workflows
 - ⚡ **Real-time Execution** - Execute workflows and see results immediately
 - ⌨️ **Keyboard Shortcuts** - Efficient workflow creation with keyboard shortcuts

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,7 +37,9 @@ import { RelationshipNode } from "@/components/nodes/relationship-node";
 import { AnalysisNode } from "@/components/nodes/analysis-node";
 import { WatchNode } from "@/components/nodes/watch-node";
 import { ParameterNode } from "@/components/nodes/parameter-node";
+import { PythonScriptNode } from "@/components/nodes/python-script-node";
 import { Toaster } from "@/components/toaster";
+import { PythonEditorDialog } from "@/components/dialogs/python-editor-dialog";
 import { WorkflowExecutor } from "@/lib/workflow-executor";
 import { loadIfcFile, getIfcFile } from "@/lib/ifc-utils";
 import { useToast } from "@/hooks/use-toast";
@@ -68,6 +70,7 @@ const nodeTypes: NodeTypes = {
   analysisNode: AnalysisNode,
   watchNode: WatchNode,
   parameterNode: ParameterNode,
+  pythonNode: PythonScriptNode,
 };
 
 // Custom node style to highlight selected nodes
@@ -109,6 +112,7 @@ function FlowWithProvider() {
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge[]>([]);
   const [selectedNode, setSelectedNode] = useState<Node | null>(null);
   const [editingNode, setEditingNode] = useState<Node | null>(null);
+  const [pythonEditorNode, setPythonEditorNode] = useState<Node | null>(null);
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const { toast } = useToast();
   const { shortcuts } = useKeyboardShortcuts();
@@ -462,7 +466,10 @@ function FlowWithProvider() {
   // Handle node double-click to open properties panel
   const onNodeDoubleClick = useCallback(
     (event: React.MouseEvent, node: Node) => {
-      // Only open edit mode on double click if we're not already editing
+      if (node.type === "pythonNode") {
+        setPythonEditorNode(node);
+        return;
+      }
       if (!editingNode) {
         setEditingNode(node);
       }
@@ -1597,6 +1604,22 @@ function FlowWithProvider() {
           node={editingNode}
           setNodes={setNodes as React.Dispatch<React.SetStateAction<any[]>>}
           setSelectedNode={setEditingNode}
+        />
+      )}
+      {pythonEditorNode && (
+        <PythonEditorDialog
+          node={pythonEditorNode}
+          onClose={() => setPythonEditorNode(null)}
+          onSave={(id, script) => {
+            setNodes((nds) =>
+              nds.map((n) =>
+                n.id === id
+                  ? { ...n, data: { ...n.data, properties: { ...(n.data as any).properties, script } } }
+                  : n
+              )
+            )
+            setPythonEditorNode(null)
+          }}
         />
       )}
       <Toaster />

--- a/components/dialogs/help-dialog.tsx
+++ b/components/dialogs/help-dialog.tsx
@@ -629,6 +629,33 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
                     </Button>
                   </CardFooter>
                 </Card>
+
+                <Card>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base">
+                      Python Aggregation
+                    </CardTitle>
+                    <CardDescription>
+                      Use the Python node to group elements and compute stats
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="text-sm text-muted-foreground">
+                    <p>
+                      Demonstrates running custom Python code that processes
+                      elements and outputs a table readable by a Watch node.
+                    </p>
+                  </CardContent>
+                  <CardFooter className="pt-0">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="w-full"
+                      onClick={() => window.open('/docs/python-node.md', '_blank')}
+                    >
+                      View Script
+                    </Button>
+                  </CardFooter>
+                </Card>
               </div>
 
               <div className="flex justify-center mt-6">

--- a/components/dialogs/python-editor-dialog.tsx
+++ b/components/dialogs/python-editor-dialog.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+
+interface PythonEditorDialogProps {
+  node: any | null
+  onClose: () => void
+  onSave: (id: string, script: string) => void
+}
+
+const keywords = /(\b(?:def|class|return|import|from|as|if|else|elif|for|while|try|except|with|lambda|yield|in|is|not|and|or|pass|break|continue|print)\b)/g
+
+function highlight(code: string) {
+  let html = code
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+  html = html.replace(/(#[^\n]*)/g, '<span class="text-gray-400">$1</span>')
+  html = html.replace(/("[^"]*"|'[^']*')/g, '<span class="text-green-600">$1</span>')
+  html = html.replace(keywords, '<span class="text-purple-600 font-semibold">$1</span>')
+  return html
+}
+
+export function PythonEditorDialog({ node, onClose, onSave }: PythonEditorDialogProps) {
+  const [script, setScript] = useState("")
+
+  useEffect(() => {
+    if (node) {
+      setScript(node.data?.properties?.script || "")
+    }
+  }, [node])
+
+  if (!node) return null
+
+  return (
+    <Dialog open={!!node} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="sm:max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>Edit Python Script</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4 py-2">
+          <div className="relative">
+            <pre className="pointer-events-none absolute inset-0 p-2 text-xs font-mono whitespace-pre-wrap overflow-auto" dangerouslySetInnerHTML={{ __html: highlight(script) }} />
+            <Textarea
+              value={script}
+              onChange={(e) => setScript(e.target.value)}
+              className="relative bg-transparent text-transparent caret-white font-mono text-xs h-40 overflow-auto"
+              style={{ zIndex: 1 }}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>Cancel</Button>
+          <Button onClick={() => onSave(node.id, script)}>Save</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+

--- a/components/nodes/python-script-node.tsx
+++ b/components/nodes/python-script-node.tsx
@@ -1,51 +1,21 @@
 "use client"
 
-import { memo, useState } from "react"
-import { Handle, Position, NodeProps, useReactFlow } from "reactflow"
+import { memo } from "react"
+import { Handle, Position, type NodeProps } from "reactflow"
 import { Code } from "lucide-react"
 import { PythonScriptNodeData } from "./node-types"
 
-export const PythonScriptNode = memo(({ data, id, isConnectable }: NodeProps<PythonScriptNodeData>) => {
-  const [expanded, setExpanded] = useState(false)
-  const { setNodes } = useReactFlow()
+export const PythonScriptNode = memo(({ data, isConnectable }: NodeProps<PythonScriptNodeData>) => {
   const script = data.properties?.script || ""
-  const consoleText = data.console || ""
-
-  const updateScript = (value: string) => {
-    setNodes(nodes =>
-      nodes.map(n =>
-        n.id === id
-          ? { ...n, data: { ...n.data, properties: { ...n.data.properties, script: value } } }
-          : n
-      )
-    )
-  }
+  const preview = script.split("\n")[0] || "Double-click to edit"
 
   return (
-    <div className="bg-white dark:bg-gray-800 border-2 border-orange-500 dark:border-orange-400 rounded-md w-60 shadow-md">
-      <div
-        className="bg-orange-500 text-white px-3 py-1 flex items-center justify-between cursor-pointer"
-        onClick={() => setExpanded(!expanded)}
-      >
-        <div className="flex items-center gap-2">
-          <Code className="h-4 w-4" />
-          <div className="text-sm font-medium truncate" title={data.label}>{data.label}</div>
-        </div>
-        <div className="text-xs">{expanded ? "Hide" : "Edit"}</div>
+    <div className="bg-white dark:bg-gray-800 border-2 border-orange-500 dark:border-orange-400 rounded-md w-48 shadow-md">
+      <div className="bg-orange-500 text-white px-3 py-1 flex items-center gap-2">
+        <Code className="h-4 w-4" />
+        <div className="text-sm font-medium truncate" title={data.label}>{data.label}</div>
       </div>
-      {expanded && (
-        <div className="p-2 text-xs space-y-2">
-          <textarea
-            className="w-full h-32 p-1 font-mono border rounded bg-gray-50 dark:bg-gray-900"
-            value={script}
-            onChange={e => updateScript(e.target.value)}
-            placeholder="# Write Python script here"
-          />
-          <div className="h-24 overflow-auto bg-black text-green-300 font-mono p-1 rounded whitespace-pre-wrap">
-            {consoleText || "Console output"}
-          </div>
-        </div>
-      )}
+      <div className="p-3 text-xs font-mono truncate" title={script}>{preview}</div>
       <Handle type="target" position={Position.Left} id="input" style={{ background: "#555", width: 8, height: 8 }} isConnectable={isConnectable} />
       <Handle type="source" position={Position.Right} id="output" style={{ background: "#555", width: 8, height: 8 }} isConnectable={isConnectable} />
     </div>

--- a/docs/python-node.md
+++ b/docs/python-node.md
@@ -1,0 +1,70 @@
+# Python Script Node
+
+The **Python Script** node allows you to run custom Python code inside your workflow. It receives input data from connected nodes through the `input_data` variable and can output data on its `output` handle.
+
+## Editing Scripts
+
+Double‑click the node to open the in‑canvas editor. The editor supports basic syntax highlighting and lets you modify the script without leaving the canvas.
+
+## Example
+
+Below is an example script that groups elements by type, predefined type and storey, while computing average dimensions:
+
+```python
+from collections import defaultdict
+import hashlib
+
+elements = input_data.get("elements", [])
+
+def get_storey_name(el):
+    for rel in el.get("ContainedInStructure", []):
+        relating = rel.get("RelatingStructure", {})
+        if relating.get("type") == "IfcBuildingStorey":
+            return relating.get("Name") or relating.get("GlobalId")
+    return "—"
+
+def checksum(guid):
+    if not guid:
+        return "n/a"
+    return hashlib.md5(guid.encode()).hexdigest()[:6]
+
+def is_load_bearing(eltype):
+    return eltype in ["IfcWall", "IfcColumn", "IfcBeam"]
+
+agg = defaultdict(lambda: {"Count": 0, "Heights": [], "Widths": []})
+
+for el in elements:
+    if not isinstance(el, dict):
+        continue
+    eltype = el.get("type", "???")
+    pred = el.get("PredefinedType") or el.get("ObjectType") or "—"
+    storey = get_storey_name(el)
+    key = f"{eltype} | {pred} | {storey}"
+
+    agg[key]["Count"] += 1
+    if "OverallHeight" in el:
+        agg[key]["Heights"].append(el["OverallHeight"])
+    if "OverallWidth" in el:
+        agg[key]["Widths"].append(el["OverallWidth"])
+    agg[key]["LastGUID"] = checksum(el.get("GlobalId"))
+
+# Convert to Watch-friendly format
+result = []
+for k, v in sorted(agg.items()):
+    eltype, pred, storey = k.split(" | ")
+    avg_h = round(sum(v["Heights"]) / len(v["Heights"]), 2) if v["Heights"] else None
+    avg_w = round(sum(v["Widths"]) / len(v["Widths"]) , 2) if v["Widths"] else None
+    result.append({
+        "Type": eltype,
+        "Predefined": pred,
+        "Storey": storey,
+        "Count": v["Count"],
+        "AvgHeight": avg_h,
+        "AvgWidth": avg_w,
+        "Checksum": v["LastGUID"],
+        "LoadBearing?": "✓" if is_load_bearing(eltype) else ""
+    })
+```
+
+The script produces a list of dictionaries ready for consumption by a **Watch** node for inspection or further processing.
+


### PR DESCRIPTION
## Summary
- style python node to match others and show preview text
- add in-canvas Python editor dialog with basic syntax highlighting
- don't open sidebar for python node editing
- link new Python script example in help dialog
- document Python node usage
- list Python node in README

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877ba6cab5c8320847c1afad5e12017