### PR TITLE
Add Python script editor modal and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ IFC Flow Map provides a graphical interface for viewing, filtering, transforming
   - 🔗 **Relationship Node** - Query element relationships
   - 📊 **Analysis Node** - Perform analyses like clash detection
   - 👀 **Watch Node** - Monitor element values
+  - 🐍 **Python Script Node** - Run custom Python code in your workflow
   - ⚙️ **Parameter Node** - Define workflow parameters
 - 💾 **Workflow Storage** - Save and load workflows
 - ⚡ **Real-time Execution** - Execute workflows and see results immediately
@@ -116,6 +117,7 @@ To learn more about the technologies used:
 - [React Flow Documentation](https://reactflow.dev/docs/introduction/)
 - [Radix UI Documentation](https://www.radix-ui.com/docs/primitives/overview/introduction)
 - [IfcOpenShell Documentation](https://blenderbim.org/docs-python/)
+- [Python Node Guide](docs/python-node.md)
 
 ## 🚀 Deployment
 

--- a/components/dialogs/help-dialog.tsx
+++ b/components/dialogs/help-dialog.tsx
@@ -178,6 +178,18 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
       ],
     },
     {
+      id: "python",
+      title: "Using the Python Script Node",
+      icon: <Code className="h-5 w-5" />,
+      description: "Run custom Python to transform data.",
+      steps: [
+        "Drag a <strong>Python Script</strong> node onto the canvas",
+        "Double-click the node to open the editor",
+        "Write your Python code and assign the output to <code>result</code>",
+        "Run the workflow to execute the script",
+      ],
+    },
+    {
       id: "saving",
       title: "Saving and Loading Workflows",
       icon: <FileJson className="h-5 w-5" />,
@@ -621,6 +633,25 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
                     <p>
                       Learn how to export IFC data to CSV, JSON, and other
                       formats for further processing.
+                    </p>
+                  </CardContent>
+                  <CardFooter className="pt-0">
+                    <Button variant="outline" size="sm" className="w-full">
+                      Load Example
+                    </Button>
+                  </CardFooter>
+                </Card>
+
+                <Card>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base">Python Aggregation</CardTitle>
+                    <CardDescription>
+                      Summarize elements with a custom script
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="text-sm text-muted-foreground">
+                    <p>
+                      Demonstrates grouping elements in Python and computing averages.
                     </p>
                   </CardContent>
                   <CardFooter className="pt-0">

--- a/components/dialogs/python-editor-dialog.tsx
+++ b/components/dialogs/python-editor-dialog.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Label } from "@/components/ui/label"
+
+interface PythonEditorDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  script: string
+  onChange: (value: string) => void
+  consoleText?: string
+}
+
+export function PythonEditorDialog({
+  open,
+  onOpenChange,
+  script,
+  onChange,
+  consoleText,
+}: PythonEditorDialogProps) {
+  const [localScript, setLocalScript] = useState(script)
+
+  useEffect(() => {
+    setLocalScript(script)
+  }, [script])
+
+  const handleSave = () => {
+    onChange(localScript)
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Edit Python Script</DialogTitle>
+          <DialogDescription>
+            Modify the script and apply your changes.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="py-script">Script</Label>
+            <Textarea
+              id="py-script"
+              value={localScript}
+              onChange={(e) => setLocalScript(e.target.value)}
+              className="font-mono h-40"
+              placeholder="# Write Python script here"
+            />
+          </div>
+          {consoleText !== undefined && (
+            <div className="space-y-2">
+              <Label>Console</Label>
+              <ScrollArea className="h-24">
+                <pre className="bg-black text-green-300 font-mono p-2 rounded whitespace-pre-wrap">
+                  {consoleText || "Console output"}
+                </pre>
+              </ScrollArea>
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave}>Apply</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/nodes/python-script-node.tsx
+++ b/components/nodes/python-script-node.tsx
@@ -4,9 +4,10 @@ import { memo, useState } from "react"
 import { Handle, Position, NodeProps, useReactFlow } from "reactflow"
 import { Code } from "lucide-react"
 import { PythonScriptNodeData } from "./node-types"
+import { PythonEditorDialog } from "@/components/dialogs/python-editor-dialog"
 
 export const PythonScriptNode = memo(({ data, id, isConnectable }: NodeProps<PythonScriptNodeData>) => {
-  const [expanded, setExpanded] = useState(false)
+  const [editorOpen, setEditorOpen] = useState(false)
   const { setNodes } = useReactFlow()
   const script = data.properties?.script || ""
   const consoleText = data.console || ""
@@ -22,33 +23,41 @@ export const PythonScriptNode = memo(({ data, id, isConnectable }: NodeProps<Pyt
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 border-2 border-orange-500 dark:border-orange-400 rounded-md w-60 shadow-md">
+    <>
       <div
-        className="bg-orange-500 text-white px-3 py-1 flex items-center justify-between cursor-pointer"
-        onClick={() => setExpanded(!expanded)}
+        onDoubleClick={(e) => {
+          e.stopPropagation()
+          setEditorOpen(true)
+        }}
+        className="bg-white dark:bg-gray-800 border-2 border-orange-500 dark:border-orange-400 rounded-md w-48 shadow-md"
       >
-        <div className="flex items-center gap-2">
+        <div className="bg-orange-500 text-white px-3 py-1 flex items-center gap-2">
           <Code className="h-4 w-4" />
-          <div className="text-sm font-medium truncate" title={data.label}>{data.label}</div>
+          <div className="text-sm font-medium truncate">{data.label}</div>
         </div>
-        <div className="text-xs">{expanded ? "Hide" : "Edit"}</div>
+        <Handle
+          type="target"
+          position={Position.Left}
+          id="input"
+          style={{ background: "#555", width: 8, height: 8 }}
+          isConnectable={isConnectable}
+        />
+        <Handle
+          type="source"
+          position={Position.Right}
+          id="output"
+          style={{ background: "#555", width: 8, height: 8 }}
+          isConnectable={isConnectable}
+        />
       </div>
-      {expanded && (
-        <div className="p-2 text-xs space-y-2">
-          <textarea
-            className="w-full h-32 p-1 font-mono border rounded bg-gray-50 dark:bg-gray-900"
-            value={script}
-            onChange={e => updateScript(e.target.value)}
-            placeholder="# Write Python script here"
-          />
-          <div className="h-24 overflow-auto bg-black text-green-300 font-mono p-1 rounded whitespace-pre-wrap">
-            {consoleText || "Console output"}
-          </div>
-        </div>
-      )}
-      <Handle type="target" position={Position.Left} id="input" style={{ background: "#555", width: 8, height: 8 }} isConnectable={isConnectable} />
-      <Handle type="source" position={Position.Right} id="output" style={{ background: "#555", width: 8, height: 8 }} isConnectable={isConnectable} />
-    </div>
+      <PythonEditorDialog
+        open={editorOpen}
+        onOpenChange={setEditorOpen}
+        script={script}
+        onChange={updateScript}
+        consoleText={consoleText}
+      />
+    </>
   )
 })
 

--- a/docs/python-node.md
+++ b/docs/python-node.md
@@ -1,0 +1,64 @@
+# Python Script Node
+
+The **Python Script** node lets you execute custom Python code as part of your workflow. Double-click the node on the canvas to open the editor, modify the script, and press **Apply** to save the changes.
+
+The script should assign its output to a variable named `result`. The input data is available as `input_data`.
+
+## Example
+
+```python
+from collections import defaultdict
+import hashlib
+
+elements = input_data.get("elements", [])
+
+def get_storey_name(el):
+    for rel in el.get("ContainedInStructure", []):
+        relating = rel.get("RelatingStructure", {})
+        if relating.get("type") == "IfcBuildingStorey":
+            return relating.get("Name") or relating.get("GlobalId")
+    return "—"
+
+def checksum(guid):
+    if not guid:
+        return "n/a"
+    return hashlib.md5(guid.encode()).hexdigest()[:6]
+
+def is_load_bearing(eltype):
+    return eltype in ["IfcWall", "IfcColumn", "IfcBeam"]
+
+agg = defaultdict(lambda: {"Count": 0, "Heights": [], "Widths": []})
+
+for el in elements:
+    if not isinstance(el, dict):
+        continue
+    eltype = el.get("type", "???")
+    pred = el.get("PredefinedType") or el.get("ObjectType") or "—"
+    storey = get_storey_name(el)
+    key = f"{eltype} | {pred} | {storey}"
+
+    agg[key]["Count"] += 1
+    if "OverallHeight" in el:
+        agg[key]["Heights"].append(el["OverallHeight"])
+    if "OverallWidth" in el:
+        agg[key]["Widths"].append(el["OverallWidth"])
+    agg[key]["LastGUID"] = checksum(el.get("GlobalId"))
+
+result = []
+for k, v in sorted(agg.items()):
+    eltype, pred, storey = k.split(" | ")
+    avg_h = round(sum(v["Heights"]) / len(v["Heights"]), 2) if v["Heights"] else None
+    avg_w = round(sum(v["Widths"]) / len(v["Widths"]), 2) if v["Widths"] else None
+    result.append({
+        "Type": eltype,
+        "Predefined": pred,
+        "Storey": storey,
+        "Count": v["Count"],
+        "AvgHeight": avg_h,
+        "AvgWidth": avg_w,
+        "Checksum": v["LastGUID"],
+        "LoadBearing?": "✓" if is_load_bearing(eltype) else "",
+    })
+```
+
+This example groups elements by type and storey and computes average sizes. See the repository for the full sample.


### PR DESCRIPTION
## Summary
- add Python editor dialog and connect it to python node
- polish python node UI to match others
- document Python node in README and help dialog
- include example script in docs

## Testing
- `npm run lint` *(fails: interactive ESLint prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6877ba6cab5c8320847c1afad5e12017