### PR TITLE
Simplify keyboard shortcuts

### DIFF
--- a/components/dialogs/help-dialog.tsx
+++ b/components/dialogs/help-dialog.tsx
@@ -38,7 +38,6 @@ import {
   Copy,
   Check,
   Command,
-  FileDown,
 } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Input } from "@/components/ui/input";
@@ -62,7 +61,6 @@ interface Shortcut {
   id: string;
   name: string;
   keys: string;
-  defaultKeys: string;
   category: string;
 }
 
@@ -71,13 +69,10 @@ type ShortcutsByCategory = Record<string, Shortcut[]>;
 
 export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
   const [activeTab, setActiveTab] = useState("shortcuts");
-  const [editingShortcut, setEditingShortcut] = useState<string | null>(null);
-  const [listeningForKeys, setListeningForKeys] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [copiedId, setCopiedId] = useState<string | null>(null);
   // Explicitly type the shortcuts from the hook if possible, otherwise use the local Shortcut type
-  const { shortcuts, updateShortcut, resetShortcut, resetAllShortcuts } =
-    useKeyboardShortcuts();
+  const { shortcuts } = useKeyboardShortcuts();
   const dialogRef = useRef<HTMLDivElement>(null);
 
   // Group shortcuts by category
@@ -100,39 +95,6 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
         s.category.toLowerCase().includes(searchQuery.toLowerCase())
     )
     : null;
-
-  // Handle shortcut edit
-  const handleShortcutClick = (id: string) => {
-    setEditingShortcut(id);
-    setListeningForKeys(true);
-  };
-
-  // Handle key press for shortcut editing
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (!listeningForKeys || !editingShortcut) return;
-
-    e.preventDefault();
-
-    // Build key combination
-    const keys = [];
-    if (e.ctrlKey) keys.push("ctrl");
-    if (e.altKey) keys.push("alt");
-    if (e.shiftKey) keys.push("shift");
-    if (e.metaKey) keys.push("meta");
-
-    // Add the main key if it's not a modifier
-    const key = e.key.toLowerCase();
-    if (!["control", "alt", "shift", "meta"].includes(key)) {
-      keys.push(key);
-    }
-
-    // Only update if we have at least one key
-    if (keys.length > 0) {
-      updateShortcut(editingShortcut, keys.join("+"));
-      setListeningForKeys(false);
-      setEditingShortcut(null);
-    }
-  };
 
   // Copy shortcut to clipboard
   const handleCopyShortcut = (id: string, keys: string) => {
@@ -207,7 +169,6 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
       <DialogContent
         ref={dialogRef}
         className="sm:max-w-4xl max-h-[90vh] overflow-hidden flex flex-col bg-background"
-        onKeyDown={handleKeyDown}
       >
         <DialogHeader className="pb-2 border-b">
           <DialogTitle className="flex items-center gap-2 text-xl">
@@ -264,9 +225,6 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
                     onChange={(e) => setSearchQuery(e.target.value)}
                   />
                 </div>
-                <Button variant="outline" size="sm" onClick={resetAllShortcuts}>
-                  Reset All
-                </Button>
               </div>
             )}
           </div>
@@ -276,19 +234,7 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
             className="flex-1 overflow-hidden flex flex-col mt-0 border rounded-md"
             tabIndex={0}
           >
-            {listeningForKeys && (
-              <Alert className="m-4 mb-0">
-                <AlertTitle className="flex items-center gap-2">
-                  <Keyboard className="h-4 w-4" />
-                  Listening for key press
-                </AlertTitle>
-                <AlertDescription>
-                  Press the key combination you want to use for this shortcut
-                </AlertDescription>
-              </Alert>
-            )}
-
-            <ScrollArea className="flex-1 p-4">
+            <ScrollArea className="flex-1 h-full p-4">
               {filteredShortcuts ? (
                 <div className="space-y-4">
                   <h3 className="text-lg font-medium">Search Results</h3>
@@ -298,7 +244,6 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
                         <TableHead>Category</TableHead>
                         <TableHead>Action</TableHead>
                         <TableHead>Shortcut</TableHead>
-                        <TableHead className="w-[140px]">Actions</TableHead>
                       </TableRow>
                     </TableHeader>
                     <TableBody>
@@ -308,49 +253,25 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
                             {shortcut.category}
                           </TableCell>
                           <TableCell>{shortcut.name}</TableCell>
-                          <TableCell>
+                          <TableCell className="flex items-center gap-2">
+                            <span className="font-mono">
+                              {formatKeyCombination(shortcut.keys)}
+                            </span>
                             <Button
                               variant="ghost"
-                              size="sm"
-                              className={`font-mono ${editingShortcut === shortcut.id
-                                ? "bg-primary/20"
-                                : ""
-                                }`}
-                              onClick={() => handleShortcutClick(shortcut.id)}
+                              size="icon"
+                              className="h-8 w-8"
+                              onClick={() =>
+                                handleCopyShortcut(shortcut.id, shortcut.keys)
+                              }
+                              title="Copy shortcut"
                             >
-                              {formatKeyCombination(shortcut.keys)}
+                              {copiedId === shortcut.id ? (
+                                <Check className="h-4 w-4 text-green-500" />
+                              ) : (
+                                <Copy className="h-4 w-4" />
+                              )}
                             </Button>
-                          </TableCell>
-                          <TableCell>
-                            <div className="flex gap-1">
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                className="h-8 w-8"
-                                onClick={() =>
-                                  handleCopyShortcut(shortcut.id, shortcut.keys)
-                                }
-                                title="Copy shortcut"
-                              >
-                                {copiedId === shortcut.id ? (
-                                  <Check className="h-4 w-4 text-green-500" />
-                                ) : (
-                                  <Copy className="h-4 w-4" />
-                                )}
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                className="h-8 w-8"
-                                onClick={() => resetShortcut(shortcut.id)}
-                                disabled={
-                                  shortcut.keys === shortcut.defaultKeys
-                                }
-                                title="Reset to default"
-                              >
-                                <FileDown className="h-4 w-4" />
-                              </Button>
-                            </div>
                           </TableCell>
                         </TableRow>
                       ))}
@@ -384,7 +305,6 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
                           <TableRow>
                             <TableHead>Action</TableHead>
                             <TableHead>Shortcut</TableHead>
-                            <TableHead className="w-[140px]">Actions</TableHead>
                           </TableRow>
                         </TableHeader>
                         <TableBody>
@@ -392,54 +312,25 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
                             (shortcut: Shortcut) => (
                               <TableRow key={shortcut.id}>
                                 <TableCell>{shortcut.name}</TableCell>
-                                <TableCell>
+                                <TableCell className="flex items-center gap-2">
+                                  <span className="font-mono">
+                                    {formatKeyCombination(shortcut.keys)}
+                                  </span>
                                   <Button
                                     variant="ghost"
-                                    size="sm"
-                                    className={`font-mono ${editingShortcut === shortcut.id
-                                      ? "bg-primary/20"
-                                      : ""
-                                      }`}
+                                    size="icon"
+                                    className="h-8 w-8"
                                     onClick={() =>
-                                      handleShortcutClick(shortcut.id)
+                                      handleCopyShortcut(shortcut.id, shortcut.keys)
                                     }
+                                    title="Copy shortcut"
                                   >
-                                    {formatKeyCombination(shortcut.keys)}
+                                    {copiedId === shortcut.id ? (
+                                      <Check className="h-4 w-4 text-green-500" />
+                                    ) : (
+                                      <Copy className="h-4 w-4" />
+                                    )}
                                   </Button>
-                                </TableCell>
-                                <TableCell>
-                                  <div className="flex gap-1">
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      className="h-8 w-8"
-                                      onClick={() =>
-                                        handleCopyShortcut(
-                                          shortcut.id,
-                                          shortcut.keys
-                                        )
-                                      }
-                                      title="Copy shortcut"
-                                    >
-                                      {copiedId === shortcut.id ? (
-                                        <Check className="h-4 w-4 text-green-500" />
-                                      ) : (
-                                        <Copy className="h-4 w-4" />
-                                      )}
-                                    </Button>
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      className="h-8 w-8"
-                                      onClick={() => resetShortcut(shortcut.id)}
-                                      disabled={
-                                        shortcut.keys === shortcut.defaultKeys
-                                      }
-                                      title="Reset to default"
-                                    >
-                                      <FileDown className="h-4 w-4" />
-                                    </Button>
-                                  </div>
                                 </TableCell>
                               </TableRow>
                             )

--- a/lib/keyboard-shortcuts.ts
+++ b/lib/keyboard-shortcuts.ts
@@ -1,27 +1,38 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useMemo } from "react"
 
 export interface KeyboardShortcut {
   id: string
   name: string
   description: string
-  defaultKeys: string
   keys: string
   category: "file" | "edit" | "view" | "workflow" | "navigation"
   action: () => void
 }
 
 // Helper to detect platform
-export const isMac = typeof navigator !== "undefined" ? navigator.platform.toUpperCase().indexOf("MAC") >= 0 : false
+export const isMac =
+  typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.platform)
 
 // Format key combination for display
 export function formatKeyCombination(keys: string): string {
   if (isMac) {
-    return keys.replace(/ctrl/gi, "⌘").replace(/alt/gi, "⌥").replace(/shift/gi, "⇧").replace(/\+/g, " ")
-  } else {
-    return keys.replace(/ctrl/gi, "Ctrl").replace(/alt/gi, "Alt").replace(/shift/gi, "Shift").replace(/\+/g, "+")
+    return keys
+      .replace(/mod/gi, "⌘")
+      .replace(/meta/gi, "⌘")
+      .replace(/ctrl/gi, "⌘")
+      .replace(/alt/gi, "⌥")
+      .replace(/shift/gi, "⇧")
+      .replace(/\+/g, " ")
   }
+  return keys
+    .replace(/mod/gi, "Ctrl")
+    .replace(/meta/gi, "Ctrl")
+    .replace(/ctrl/gi, "Ctrl")
+    .replace(/alt/gi, "Alt")
+    .replace(/shift/gi, "Shift")
+    .replace(/\+/g, "+")
 }
 
 // Parse key combination for hotkey library
@@ -30,252 +41,169 @@ export function parseKeyCombination(keys: string): string {
 }
 
 // Default keyboard shortcuts
-export const defaultShortcuts: KeyboardShortcut[] = [
-  {
-    id: "open-file",
-    name: "Open File",
-    description: "Open an IFC file",
-    defaultKeys: "ctrl+o",
-    keys: "ctrl+o",
-    category: "file",
-    action: () => { },
-  },
-  {
-    id: "save-workflow",
-    name: "Save Workflow",
-    description: "Save current workflow to library",
-    defaultKeys: "ctrl+s",
-    keys: "ctrl+s",
-    category: "file",
-    action: () => { },
-  },
-  {
-    id: "save-workflow-locally",
-    name: "Save Workflow Locally",
-    description: "Save current workflow to local file",
-    defaultKeys: "ctrl+shift+s",
-    keys: "ctrl+shift+s",
-    category: "file",
-    action: () => { },
-  },
-  {
-    id: "open-workflow-library",
-    name: "Open Workflow Library",
-    description: "Open the workflow library",
-    defaultKeys: "ctrl+l",
-    keys: "ctrl+l",
-    category: "file",
-    action: () => { },
-  },
-  {
-    id: "undo",
-    name: "Undo",
-    description: "Undo last action",
-    defaultKeys: "ctrl+z",
-    keys: "ctrl+z",
-    category: "edit",
-    action: () => { },
-  },
-  {
-    id: "redo",
-    name: "Redo",
-    description: "Redo last undone action",
-    defaultKeys: "ctrl+shift+z",
-    keys: "ctrl+shift+z",
-    category: "edit",
-    action: () => { },
-  },
-  {
-    id: "select-all",
-    name: "Select All",
-    description: "Select all nodes",
-    defaultKeys: "ctrl+a",
-    keys: "ctrl+a",
-    category: "edit",
-    action: () => { },
-  },
-  {
-    id: "cut",
-    name: "Cut",
-    description: "Cut selected nodes",
-    defaultKeys: "ctrl+x",
-    keys: "ctrl+x",
-    category: "edit",
-    action: () => { },
-  },
-  {
-    id: "copy",
-    name: "Copy",
-    description: "Copy selected nodes",
-    defaultKeys: "ctrl+c",
-    keys: "ctrl+c",
-    category: "edit",
-    action: () => { },
-  },
-  {
-    id: "paste",
-    name: "Paste",
-    description: "Paste copied nodes",
-    defaultKeys: "ctrl+v",
-    keys: "ctrl+v",
-    category: "edit",
-    action: () => { },
-  },
-  {
-    id: "delete",
-    name: "Delete",
-    description: "Delete selected nodes",
-    defaultKeys: "delete",
-    keys: "delete",
-    category: "edit",
-    action: () => { },
-  },
-  {
-    id: "run-workflow",
-    name: "Run Workflow",
-    description: "Run the current workflow",
-    defaultKeys: "f5",
-    keys: "f5",
-    category: "workflow",
-    action: () => { },
-  },
-  {
-    id: "zoom-in",
-    name: "Zoom In",
-    description: "Zoom in the canvas",
-    defaultKeys: "ctrl+=",
-    keys: "ctrl+=",
-    category: "view",
-    action: () => { },
-  },
-  {
-    id: "zoom-out",
-    name: "Zoom Out",
-    description: "Zoom out the canvas",
-    defaultKeys: "ctrl+-",
-    keys: "ctrl+-",
-    category: "view",
-    action: () => { },
-  },
-  {
-    id: "fit-view",
-    name: "Fit View",
-    description: "Fit all nodes in view",
-    defaultKeys: "ctrl+0",
-    keys: "ctrl+0",
-    category: "view",
-    action: () => { },
-  },
-  {
-    id: "toggle-grid",
-    name: "Toggle Grid",
-    description: "Toggle grid visibility",
-    defaultKeys: "ctrl+g",
-    keys: "ctrl+g",
-    category: "view",
-    action: () => { },
-  },
-  {
-    id: "toggle-minimap",
-    name: "Toggle Minimap",
-    description: "Toggle minimap visibility",
-    defaultKeys: "ctrl+m",
-    keys: "ctrl+m",
-    category: "view",
-    action: () => { },
-  },
-  {
-    id: "help",
-    name: "Help",
-    description: "Open help dialog",
-    defaultKeys: "f1",
-    keys: "f1",
-    category: "navigation",
-    action: () => { },
-  },
-  {
-    id: "keyboard-shortcuts",
-    name: "Keyboard Shortcuts",
-    description: "Show keyboard shortcuts",
-    defaultKeys: "shift+f1",
-    keys: "shift+f1",
-    category: "navigation",
-    action: () => { },
-  },
-]
-
-// Load shortcuts from localStorage
-export function loadShortcuts(): KeyboardShortcut[] {
-  if (typeof window === "undefined") return defaultShortcuts
-
-  try {
-    const savedShortcuts = localStorage.getItem("keyboard-shortcuts")
-    if (savedShortcuts) {
-      const parsed = JSON.parse(savedShortcuts) as { id: string; keys: string }[]
-
-      // Merge with defaults to ensure we have all shortcuts
-      return defaultShortcuts.map((defaultShortcut) => {
-        const savedShortcut = parsed.find((s) => s.id === defaultShortcut.id)
-        if (savedShortcut) {
-          return {
-            ...defaultShortcut,
-            keys: savedShortcut.keys,
-          }
-        }
-        return defaultShortcut
-      })
-    }
-  } catch (error) {
-    console.error("Error loading keyboard shortcuts:", error)
-  }
-
-  return defaultShortcuts
+function createDefaultShortcuts(): KeyboardShortcut[] {
+  const mod = isMac ? "meta" : "ctrl"
+  return [
+    {
+      id: "open-file",
+      name: "Open File",
+      description: "Open an IFC file",
+      keys: `${mod}+o`,
+      category: "file",
+      action: () => {},
+    },
+    {
+      id: "save-workflow",
+      name: "Save Workflow",
+      description: "Save current workflow to library",
+      keys: `${mod}+s`,
+      category: "file",
+      action: () => {},
+    },
+    {
+      id: "save-workflow-locally",
+      name: "Save Workflow Locally",
+      description: "Save current workflow to local file",
+      keys: `${mod}+shift+s`,
+      category: "file",
+      action: () => {},
+    },
+    {
+      id: "open-workflow-library",
+      name: "Open Workflow Library",
+      description: "Open the workflow library",
+      keys: `${mod}+l`,
+      category: "file",
+      action: () => {},
+    },
+    {
+      id: "undo",
+      name: "Undo",
+      description: "Undo last action",
+      keys: `${mod}+z`,
+      category: "edit",
+      action: () => {},
+    },
+    {
+      id: "redo",
+      name: "Redo",
+      description: "Redo last undone action",
+      keys: `${mod}+shift+z`,
+      category: "edit",
+      action: () => {},
+    },
+    {
+      id: "select-all",
+      name: "Select All",
+      description: "Select all nodes",
+      keys: `${mod}+a`,
+      category: "edit",
+      action: () => {},
+    },
+    {
+      id: "cut",
+      name: "Cut",
+      description: "Cut selected nodes",
+      keys: `${mod}+x`,
+      category: "edit",
+      action: () => {},
+    },
+    {
+      id: "copy",
+      name: "Copy",
+      description: "Copy selected nodes",
+      keys: `${mod}+c`,
+      category: "edit",
+      action: () => {},
+    },
+    {
+      id: "paste",
+      name: "Paste",
+      description: "Paste copied nodes",
+      keys: `${mod}+v`,
+      category: "edit",
+      action: () => {},
+    },
+    {
+      id: "delete",
+      name: "Delete",
+      description: "Delete selected nodes",
+      keys: "delete",
+      category: "edit",
+      action: () => {},
+    },
+    {
+      id: "run-workflow",
+      name: "Run Workflow",
+      description: "Run the current workflow",
+      keys: "f5",
+      category: "workflow",
+      action: () => {},
+    },
+    {
+      id: "zoom-in",
+      name: "Zoom In",
+      description: "Zoom in the canvas",
+      keys: `${mod}+=`,
+      category: "view",
+      action: () => {},
+    },
+    {
+      id: "zoom-out",
+      name: "Zoom Out",
+      description: "Zoom out the canvas",
+      keys: `${mod}+-`,
+      category: "view",
+      action: () => {},
+    },
+    {
+      id: "fit-view",
+      name: "Fit View",
+      description: "Fit all nodes in view",
+      keys: `${mod}+0`,
+      category: "view",
+      action: () => {},
+    },
+    {
+      id: "toggle-grid",
+      name: "Toggle Grid",
+      description: "Toggle grid visibility",
+      keys: `${mod}+g`,
+      category: "view",
+      action: () => {},
+    },
+    {
+      id: "toggle-minimap",
+      name: "Toggle Minimap",
+      description: "Toggle minimap visibility",
+      keys: isMac ? "meta+shift+m" : `${mod}+m`,
+      category: "view",
+      action: () => {},
+    },
+    {
+      id: "help",
+      name: "Help",
+      description: "Open help dialog",
+      keys: "f1",
+      category: "navigation",
+      action: () => {},
+    },
+    {
+      id: "keyboard-shortcuts",
+      name: "Keyboard Shortcuts",
+      description: "Show keyboard shortcuts",
+      keys: "shift+f1",
+      category: "navigation",
+      action: () => {},
+    },
+  ]
 }
 
-// Save shortcuts to localStorage
-export function saveShortcuts(shortcuts: KeyboardShortcut[]): void {
-  if (typeof window === "undefined") return
+export const defaultShortcuts = createDefaultShortcuts()
 
-  try {
-    // Only save id and keys to keep it minimal
-    const toSave = shortcuts.map(({ id, keys }) => ({ id, keys }))
-    localStorage.setItem("keyboard-shortcuts", JSON.stringify(toSave))
-  } catch (error) {
-    console.error("Error saving keyboard shortcuts:", error)
-  }
-}
-
-// Hook to use keyboard shortcuts
+// Hook to access shortcuts
 export function useKeyboardShortcuts() {
-  const [shortcuts, setShortcuts] = useState<KeyboardShortcut[]>(defaultShortcuts)
-
-  useEffect(() => {
-    setShortcuts(loadShortcuts())
-  }, [])
-
-  const updateShortcut = (id: string, newKeys: string) => {
-    const updated = shortcuts.map((shortcut) => (shortcut.id === id ? { ...shortcut, keys: newKeys } : shortcut))
-    setShortcuts(updated)
-    saveShortcuts(updated)
-  }
-
-  const resetShortcut = (id: string) => {
-    const defaultShortcut = defaultShortcuts.find((s) => s.id === id)
-    if (defaultShortcut) {
-      updateShortcut(id, defaultShortcut.defaultKeys)
-    }
-  }
-
-  const resetAllShortcuts = () => {
-    setShortcuts(defaultShortcuts)
-    saveShortcuts(defaultShortcuts)
-  }
-
-  return {
-    shortcuts,
-    updateShortcut,
-    resetShortcut,
-    resetAllShortcuts,
-  }
+  const shortcuts = useMemo(() => defaultShortcuts, [])
+  return { shortcuts }
 }
 


### PR DESCRIPTION
## Summary
- drop custom shortcut editing support
- provide OS-aware default shortcuts
- clean up help dialog and show static shortcut tables

## Testing
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6877be61f72483209472658b6b9215ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified Help dialog to display keyboard shortcuts with an option to copy them to the clipboard.

* **Refactor**
  * Removed all functionality for editing and resetting keyboard shortcuts.
  * Improved shortcut display formatting for better platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->