### PR TITLE
Refactor keyboard shortcuts and update help dialog

### DIFF
--- a/components/dialogs/help-dialog.tsx
+++ b/components/dialogs/help-dialog.tsx
@@ -29,7 +29,6 @@ import {
   Info,
   Keyboard,
   Search,
-  ChevronRight,
   ArrowRight,
   Code,
   Layers,
@@ -38,9 +37,7 @@ import {
   Copy,
   Check,
   Command,
-  FileDown,
 } from "lucide-react";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Input } from "@/components/ui/input";
 import {
   Card,
@@ -62,7 +59,6 @@ interface Shortcut {
   id: string;
   name: string;
   keys: string;
-  defaultKeys: string;
   category: string;
 }
 
@@ -71,13 +67,10 @@ type ShortcutsByCategory = Record<string, Shortcut[]>;
 
 export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
   const [activeTab, setActiveTab] = useState("shortcuts");
-  const [editingShortcut, setEditingShortcut] = useState<string | null>(null);
-  const [listeningForKeys, setListeningForKeys] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [copiedId, setCopiedId] = useState<string | null>(null);
   // Explicitly type the shortcuts from the hook if possible, otherwise use the local Shortcut type
-  const { shortcuts, updateShortcut, resetShortcut, resetAllShortcuts } =
-    useKeyboardShortcuts();
+  const { shortcuts } = useKeyboardShortcuts();
   const dialogRef = useRef<HTMLDivElement>(null);
 
   // Group shortcuts by category
@@ -100,39 +93,6 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
         s.category.toLowerCase().includes(searchQuery.toLowerCase())
     )
     : null;
-
-  // Handle shortcut edit
-  const handleShortcutClick = (id: string) => {
-    setEditingShortcut(id);
-    setListeningForKeys(true);
-  };
-
-  // Handle key press for shortcut editing
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (!listeningForKeys || !editingShortcut) return;
-
-    e.preventDefault();
-
-    // Build key combination
-    const keys = [];
-    if (e.ctrlKey) keys.push("ctrl");
-    if (e.altKey) keys.push("alt");
-    if (e.shiftKey) keys.push("shift");
-    if (e.metaKey) keys.push("meta");
-
-    // Add the main key if it's not a modifier
-    const key = e.key.toLowerCase();
-    if (!["control", "alt", "shift", "meta"].includes(key)) {
-      keys.push(key);
-    }
-
-    // Only update if we have at least one key
-    if (keys.length > 0) {
-      updateShortcut(editingShortcut, keys.join("+"));
-      setListeningForKeys(false);
-      setEditingShortcut(null);
-    }
-  };
 
   // Copy shortcut to clipboard
   const handleCopyShortcut = (id: string, keys: string) => {
@@ -207,7 +167,6 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
       <DialogContent
         ref={dialogRef}
         className="sm:max-w-4xl max-h-[90vh] overflow-hidden flex flex-col bg-background"
-        onKeyDown={handleKeyDown}
       >
         <DialogHeader className="pb-2 border-b">
           <DialogTitle className="flex items-center gap-2 text-xl">
@@ -264,9 +223,6 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
                     onChange={(e) => setSearchQuery(e.target.value)}
                   />
                 </div>
-                <Button variant="outline" size="sm" onClick={resetAllShortcuts}>
-                  Reset All
-                </Button>
               </div>
             )}
           </div>
@@ -276,19 +232,9 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
             className="flex-1 overflow-hidden flex flex-col mt-0 border rounded-md"
             tabIndex={0}
           >
-            {listeningForKeys && (
-              <Alert className="m-4 mb-0">
-                <AlertTitle className="flex items-center gap-2">
-                  <Keyboard className="h-4 w-4" />
-                  Listening for key press
-                </AlertTitle>
-                <AlertDescription>
-                  Press the key combination you want to use for this shortcut
-                </AlertDescription>
-              </Alert>
-            )}
 
-            <ScrollArea className="flex-1 p-4">
+
+            <ScrollArea className="flex-1 p-4 overflow-y-auto">
               {filteredShortcuts ? (
                 <div className="space-y-4">
                   <h3 className="text-lg font-medium">Search Results</h3>
@@ -308,18 +254,8 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
                             {shortcut.category}
                           </TableCell>
                           <TableCell>{shortcut.name}</TableCell>
-                          <TableCell>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className={`font-mono ${editingShortcut === shortcut.id
-                                ? "bg-primary/20"
-                                : ""
-                                }`}
-                              onClick={() => handleShortcutClick(shortcut.id)}
-                            >
-                              {formatKeyCombination(shortcut.keys)}
-                            </Button>
+                          <TableCell className="font-mono">
+                            {formatKeyCombination(shortcut.keys)}
                           </TableCell>
                           <TableCell>
                             <div className="flex gap-1">
@@ -337,18 +273,6 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
                                 ) : (
                                   <Copy className="h-4 w-4" />
                                 )}
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                className="h-8 w-8"
-                                onClick={() => resetShortcut(shortcut.id)}
-                                disabled={
-                                  shortcut.keys === shortcut.defaultKeys
-                                }
-                                title="Reset to default"
-                              >
-                                <FileDown className="h-4 w-4" />
                               </Button>
                             </div>
                           </TableCell>
@@ -393,19 +317,9 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
                               <TableRow key={shortcut.id}>
                                 <TableCell>{shortcut.name}</TableCell>
                                 <TableCell>
-                                  <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    className={`font-mono ${editingShortcut === shortcut.id
-                                      ? "bg-primary/20"
-                                      : ""
-                                      }`}
-                                    onClick={() =>
-                                      handleShortcutClick(shortcut.id)
-                                    }
-                                  >
+                                  <span className="font-mono">
                                     {formatKeyCombination(shortcut.keys)}
-                                  </Button>
+                                  </span>
                                 </TableCell>
                                 <TableCell>
                                   <div className="flex gap-1">
@@ -426,18 +340,6 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
                                       ) : (
                                         <Copy className="h-4 w-4" />
                                       )}
-                                    </Button>
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      className="h-8 w-8"
-                                      onClick={() => resetShortcut(shortcut.id)}
-                                      disabled={
-                                        shortcut.keys === shortcut.defaultKeys
-                                      }
-                                      title="Reset to default"
-                                    >
-                                      <FileDown className="h-4 w-4" />
                                     </Button>
                                   </div>
                                 </TableCell>

--- a/lib/keyboard-shortcuts.ts
+++ b/lib/keyboard-shortcuts.ts
@@ -1,281 +1,215 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useMemo } from "react"
 
 export interface KeyboardShortcut {
   id: string
   name: string
   description: string
-  defaultKeys: string
   keys: string
   category: "file" | "edit" | "view" | "workflow" | "navigation"
   action: () => void
 }
 
 // Helper to detect platform
-export const isMac = typeof navigator !== "undefined" ? navigator.platform.toUpperCase().indexOf("MAC") >= 0 : false
+export const isMac =
+  typeof navigator !== "undefined" && navigator.platform
+    ? navigator.platform.toUpperCase().includes("MAC")
+    : false
 
 // Format key combination for display
 export function formatKeyCombination(keys: string): string {
+  let formatted = keys
   if (isMac) {
-    return keys.replace(/ctrl/gi, "⌘").replace(/alt/gi, "⌥").replace(/shift/gi, "⇧").replace(/\+/g, " ")
-  } else {
-    return keys.replace(/ctrl/gi, "Ctrl").replace(/alt/gi, "Alt").replace(/shift/gi, "Shift").replace(/\+/g, "+")
+    formatted = formatted
+      .replace(/mod/gi, "⌘")
+      .replace(/cmd/gi, "⌘")
+      .replace(/ctrl/gi, "⌃")
+      .replace(/alt/gi, "⌥")
+      .replace(/shift/gi, "⇧")
+    return formatted.replace(/\+/g, " ")
   }
+  formatted = formatted
+    .replace(/mod/gi, "Ctrl")
+    .replace(/cmd/gi, "Ctrl")
+    .replace(/ctrl/gi, "Ctrl")
+    .replace(/alt/gi, "Alt")
+    .replace(/shift/gi, "Shift")
+  return formatted.replace(/\+/g, "+")
 }
 
 // Parse key combination for hotkey library
 export function parseKeyCombination(keys: string): string {
-  return keys.toLowerCase().replace(/\s+/g, "+")
+  return keys
+    .toLowerCase()
+    .replace(/cmd/g, "meta")
+    .replace(/\s+/g, "+")
 }
 
 // Default keyboard shortcuts
-export const defaultShortcuts: KeyboardShortcut[] = [
-  {
-    id: "open-file",
-    name: "Open File",
-    description: "Open an IFC file",
-    defaultKeys: "ctrl+o",
-    keys: "ctrl+o",
-    category: "file",
-    action: () => { },
-  },
-  {
-    id: "save-workflow",
-    name: "Save Workflow",
-    description: "Save current workflow to library",
-    defaultKeys: "ctrl+s",
-    keys: "ctrl+s",
-    category: "file",
-    action: () => { },
-  },
-  {
-    id: "save-workflow-locally",
-    name: "Save Workflow Locally",
-    description: "Save current workflow to local file",
-    defaultKeys: "ctrl+shift+s",
-    keys: "ctrl+shift+s",
-    category: "file",
-    action: () => { },
-  },
-  {
-    id: "open-workflow-library",
-    name: "Open Workflow Library",
-    description: "Open the workflow library",
-    defaultKeys: "ctrl+l",
-    keys: "ctrl+l",
-    category: "file",
-    action: () => { },
-  },
-  {
-    id: "undo",
-    name: "Undo",
-    description: "Undo last action",
-    defaultKeys: "ctrl+z",
-    keys: "ctrl+z",
-    category: "edit",
-    action: () => { },
-  },
-  {
-    id: "redo",
-    name: "Redo",
-    description: "Redo last undone action",
-    defaultKeys: "ctrl+shift+z",
-    keys: "ctrl+shift+z",
-    category: "edit",
-    action: () => { },
-  },
-  {
-    id: "select-all",
-    name: "Select All",
-    description: "Select all nodes",
-    defaultKeys: "ctrl+a",
-    keys: "ctrl+a",
-    category: "edit",
-    action: () => { },
-  },
-  {
-    id: "cut",
-    name: "Cut",
-    description: "Cut selected nodes",
-    defaultKeys: "ctrl+x",
-    keys: "ctrl+x",
-    category: "edit",
-    action: () => { },
-  },
-  {
-    id: "copy",
-    name: "Copy",
-    description: "Copy selected nodes",
-    defaultKeys: "ctrl+c",
-    keys: "ctrl+c",
-    category: "edit",
-    action: () => { },
-  },
-  {
-    id: "paste",
-    name: "Paste",
-    description: "Paste copied nodes",
-    defaultKeys: "ctrl+v",
-    keys: "ctrl+v",
-    category: "edit",
-    action: () => { },
-  },
-  {
-    id: "delete",
-    name: "Delete",
-    description: "Delete selected nodes",
-    defaultKeys: "delete",
-    keys: "delete",
-    category: "edit",
-    action: () => { },
-  },
-  {
-    id: "run-workflow",
-    name: "Run Workflow",
-    description: "Run the current workflow",
-    defaultKeys: "f5",
-    keys: "f5",
-    category: "workflow",
-    action: () => { },
-  },
-  {
-    id: "zoom-in",
-    name: "Zoom In",
-    description: "Zoom in the canvas",
-    defaultKeys: "ctrl+=",
-    keys: "ctrl+=",
-    category: "view",
-    action: () => { },
-  },
-  {
-    id: "zoom-out",
-    name: "Zoom Out",
-    description: "Zoom out the canvas",
-    defaultKeys: "ctrl+-",
-    keys: "ctrl+-",
-    category: "view",
-    action: () => { },
-  },
-  {
-    id: "fit-view",
-    name: "Fit View",
-    description: "Fit all nodes in view",
-    defaultKeys: "ctrl+0",
-    keys: "ctrl+0",
-    category: "view",
-    action: () => { },
-  },
-  {
-    id: "toggle-grid",
-    name: "Toggle Grid",
-    description: "Toggle grid visibility",
-    defaultKeys: "ctrl+g",
-    keys: "ctrl+g",
-    category: "view",
-    action: () => { },
-  },
-  {
-    id: "toggle-minimap",
-    name: "Toggle Minimap",
-    description: "Toggle minimap visibility",
-    defaultKeys: "ctrl+m",
-    keys: "ctrl+m",
-    category: "view",
-    action: () => { },
-  },
-  {
-    id: "help",
-    name: "Help",
-    description: "Open help dialog",
-    defaultKeys: "f1",
-    keys: "f1",
-    category: "navigation",
-    action: () => { },
-  },
-  {
-    id: "keyboard-shortcuts",
-    name: "Keyboard Shortcuts",
-    description: "Show keyboard shortcuts",
-    defaultKeys: "shift+f1",
-    keys: "shift+f1",
-    category: "navigation",
-    action: () => { },
-  },
-]
+export function getDefaultShortcuts(): KeyboardShortcut[] {
+  const mod = isMac ? "cmd" : "ctrl"
+  const shortcuts: KeyboardShortcut[] = [
+    {
+      id: "open-file",
+      name: "Open File",
+      description: "Open an IFC file",
+      keys: `${mod}+o`,
+      category: "file",
+      action: () => {},
+    },
+    {
+      id: "save-workflow",
+      name: "Save Workflow",
+      description: "Save current workflow to library",
+      keys: `${mod}+s`,
+      category: "file",
+      action: () => {},
+    },
+    {
+      id: "save-workflow-locally",
+      name: "Save Workflow Locally",
+      description: "Save current workflow to local file",
+      keys: `${mod}+shift+s`,
+      category: "file",
+      action: () => {},
+    },
+    {
+      id: "open-workflow-library",
+      name: "Open Workflow Library",
+      description: "Open the workflow library",
+      keys: `${mod}+l`,
+      category: "file",
+      action: () => {},
+    },
+    {
+      id: "undo",
+      name: "Undo",
+      description: "Undo last action",
+      keys: `${mod}+z`,
+      category: "edit",
+      action: () => {},
+    },
+    {
+      id: "redo",
+      name: "Redo",
+      description: "Redo last undone action",
+      keys: `${mod}+shift+z`,
+      category: "edit",
+      action: () => {},
+    },
+    {
+      id: "select-all",
+      name: "Select All",
+      description: "Select all nodes",
+      keys: `${mod}+a`,
+      category: "edit",
+      action: () => {},
+    },
+    {
+      id: "cut",
+      name: "Cut",
+      description: "Cut selected nodes",
+      keys: `${mod}+x`,
+      category: "edit",
+      action: () => {},
+    },
+    {
+      id: "copy",
+      name: "Copy",
+      description: "Copy selected nodes",
+      keys: `${mod}+c`,
+      category: "edit",
+      action: () => {},
+    },
+    {
+      id: "paste",
+      name: "Paste",
+      description: "Paste copied nodes",
+      keys: `${mod}+v`,
+      category: "edit",
+      action: () => {},
+    },
+    {
+      id: "delete",
+      name: "Delete",
+      description: "Delete selected nodes",
+      keys: "delete",
+      category: "edit",
+      action: () => {},
+    },
+    {
+      id: "run-workflow",
+      name: "Run Workflow",
+      description: "Run the current workflow",
+      keys: "f5",
+      category: "workflow",
+      action: () => {},
+    },
+    {
+      id: "zoom-in",
+      name: "Zoom In",
+      description: "Zoom in the canvas",
+      keys: `${mod}+=`,
+      category: "view",
+      action: () => {},
+    },
+    {
+      id: "zoom-out",
+      name: "Zoom Out",
+      description: "Zoom out the canvas",
+      keys: `${mod}+-`,
+      category: "view",
+      action: () => {},
+    },
+    {
+      id: "fit-view",
+      name: "Fit View",
+      description: "Fit all nodes in view",
+      keys: `${mod}+0`,
+      category: "view",
+      action: () => {},
+    },
+    {
+      id: "toggle-grid",
+      name: "Toggle Grid",
+      description: "Toggle grid visibility",
+      keys: `${mod}+g`,
+      category: "view",
+      action: () => {},
+    },
+    {
+      id: "toggle-minimap",
+      name: "Toggle Minimap",
+      description: "Toggle minimap visibility",
+      keys: isMac ? "cmd+shift+m" : "ctrl+m",
+      category: "view",
+      action: () => {},
+    },
+    {
+      id: "help",
+      name: "Help",
+      description: "Open help dialog",
+      keys: "f1",
+      category: "navigation",
+      action: () => {},
+    },
+    {
+      id: "keyboard-shortcuts",
+      name: "Keyboard Shortcuts",
+      description: "Show keyboard shortcuts",
+      keys: "shift+f1",
+      category: "navigation",
+      action: () => {},
+    },
+  ]
 
-// Load shortcuts from localStorage
-export function loadShortcuts(): KeyboardShortcut[] {
-  if (typeof window === "undefined") return defaultShortcuts
-
-  try {
-    const savedShortcuts = localStorage.getItem("keyboard-shortcuts")
-    if (savedShortcuts) {
-      const parsed = JSON.parse(savedShortcuts) as { id: string; keys: string }[]
-
-      // Merge with defaults to ensure we have all shortcuts
-      return defaultShortcuts.map((defaultShortcut) => {
-        const savedShortcut = parsed.find((s) => s.id === defaultShortcut.id)
-        if (savedShortcut) {
-          return {
-            ...defaultShortcut,
-            keys: savedShortcut.keys,
-          }
-        }
-        return defaultShortcut
-      })
-    }
-  } catch (error) {
-    console.error("Error loading keyboard shortcuts:", error)
-  }
-
-  return defaultShortcuts
+  return shortcuts
 }
 
-// Save shortcuts to localStorage
-export function saveShortcuts(shortcuts: KeyboardShortcut[]): void {
-  if (typeof window === "undefined") return
-
-  try {
-    // Only save id and keys to keep it minimal
-    const toSave = shortcuts.map(({ id, keys }) => ({ id, keys }))
-    localStorage.setItem("keyboard-shortcuts", JSON.stringify(toSave))
-  } catch (error) {
-    console.error("Error saving keyboard shortcuts:", error)
-  }
-}
-
-// Hook to use keyboard shortcuts
+// Hook to retrieve the keyboard shortcuts
 export function useKeyboardShortcuts() {
-  const [shortcuts, setShortcuts] = useState<KeyboardShortcut[]>(defaultShortcuts)
-
-  useEffect(() => {
-    setShortcuts(loadShortcuts())
-  }, [])
-
-  const updateShortcut = (id: string, newKeys: string) => {
-    const updated = shortcuts.map((shortcut) => (shortcut.id === id ? { ...shortcut, keys: newKeys } : shortcut))
-    setShortcuts(updated)
-    saveShortcuts(updated)
-  }
-
-  const resetShortcut = (id: string) => {
-    const defaultShortcut = defaultShortcuts.find((s) => s.id === id)
-    if (defaultShortcut) {
-      updateShortcut(id, defaultShortcut.defaultKeys)
-    }
-  }
-
-  const resetAllShortcuts = () => {
-    setShortcuts(defaultShortcuts)
-    saveShortcuts(defaultShortcuts)
-  }
-
-  return {
-    shortcuts,
-    updateShortcut,
-    resetShortcut,
-    resetAllShortcuts,
-  }
+  const shortcuts = useMemo(() => getDefaultShortcuts(), [])
+  return { shortcuts }
 }
 


### PR DESCRIPTION
## Summary
- remove user configurable shortcut code
- provide OS specific defaults
- avoid macOS shortcut conflicts
- clean up help dialog and make shortcut list scrollable

## Testing
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_6877be61f72483209472658b6b9215ad