### PR TITLE
Improve filter node functionality

### DIFF
--- a/components/properties-panel/node-property-renderer.tsx
+++ b/components/properties-panel/node-property-renderer.tsx
@@ -10,6 +10,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useState, useEffect } from "react";
+import { getLastLoadedModel, getModelPropertyNames } from "@/lib/ifc-utils";
 
 interface NodePropertyRendererProps {
   node: any;
@@ -26,6 +28,15 @@ export function NodePropertyRenderer({
   if (node.type === "ifcNode") {
     return null;
   }
+
+  const [propertyOptions, setPropertyOptions] = useState<string[]>([]);
+
+  useEffect(() => {
+    const model = getLastLoadedModel();
+    if (model) {
+      setPropertyOptions(getModelPropertyNames(model));
+    }
+  }, []);
 
   switch (node.type) {
     case "geometryNode":
@@ -99,14 +110,34 @@ export function NodePropertyRenderer({
         <div className="space-y-4">
           <div className="space-y-2">
             <Label htmlFor="property">Property</Label>
-            <Input
-              id="property"
-              value={properties.property || ""}
-              onChange={(e) =>
-                setProperties({ ...properties, property: e.target.value })
-              }
-              placeholder="e.g. Type, Material, etc."
-            />
+            {propertyOptions.length > 0 ? (
+              <Select
+                value={properties.property || ""}
+                onValueChange={(value) =>
+                  setProperties({ ...properties, property: value })
+                }
+              >
+                <SelectTrigger id="property">
+                  <SelectValue placeholder="Select property" />
+                </SelectTrigger>
+                <SelectContent>
+                  {propertyOptions.map((name) => (
+                    <SelectItem key={name} value={name}>
+                      {name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <Input
+                id="property"
+                value={properties.property || ""}
+                onChange={(e) =>
+                  setProperties({ ...properties, property: e.target.value })
+                }
+                placeholder="e.g. Pset_WallCommon.FireRating"
+              />
+            )}
           </div>
           <div className="space-y-2">
             <Label htmlFor="operator">Operator</Label>

--- a/lib/ifc-utils.ts
+++ b/lib/ifc-utils.ts
@@ -66,6 +66,25 @@ export function getLastLoadedModel(): IfcModel | null {
   return _lastLoadedModel;
 }
 
+// Get all distinct property names from a model using Pset.Property notation
+export function getModelPropertyNames(model: IfcModel | null): string[] {
+  if (!model || !model.elements) return [];
+  const names = new Set<string>();
+  for (const el of model.elements) {
+    if (el.properties) {
+      Object.keys(el.properties).forEach((p) => names.add(p));
+    }
+    if (el.psets) {
+      for (const pset in el.psets) {
+        for (const prop in el.psets[pset]) {
+          names.add(`${pset}.${prop}`);
+        }
+      }
+    }
+  }
+  return Array.from(names).sort();
+}
+
 // Function to retrieve a stored File object
 export function getIfcFile(fileName: string): File | null {
   return ifcFileCache.get(fileName) || null;

--- a/lib/workflow-executor.ts
+++ b/lib/workflow-executor.ts
@@ -269,8 +269,20 @@ export class WorkflowExecutor {
           console.warn(`No input provided to filter node ${nodeId}`);
           result = [];
         } else {
+          let elements: any = inputValues.input;
+          if (!Array.isArray(elements)) {
+            if (Array.isArray((elements as any).elements)) {
+              elements = (elements as any).elements;
+            } else {
+              console.warn(
+                `Filter node ${nodeId} received unsupported input type`
+              );
+              elements = [];
+            }
+          }
+
           result = filterElements(
-            inputValues.input,
+            elements,
             node.data.properties?.property || "",
             node.data.properties?.operator || "equals",
             node.data.properties?.value || ""


### PR DESCRIPTION
## Summary
- handle non-array inputs in `filterNode`
- expose a helper to list all model properties
- show property dropdown using IFC notation when editing filter node

## Testing
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6877d935fd78832097626c674ba99ca8