### PR TITLE
Fix filter node input and show property suggestions

### DIFF
--- a/components/properties-panel/node-property-renderer.tsx
+++ b/components/properties-panel/node-property-renderer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -10,6 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { getLastLoadedModel } from "@/lib/ifc-utils";
 
 interface NodePropertyRendererProps {
   node: any;
@@ -22,6 +24,28 @@ export function NodePropertyRenderer({
   properties,
   setProperties,
 }: NodePropertyRendererProps) {
+  const [availableProps, setAvailableProps] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (node.type === "filterNode") {
+      const model = getLastLoadedModel();
+      if (model) {
+        const propSet = new Set<string>();
+        model.elements.forEach((el) => {
+          Object.keys(el.properties || {}).forEach((p) => propSet.add(p));
+          if (el.psets) {
+            for (const psetName in el.psets) {
+              const pset = el.psets[psetName];
+              Object.keys(pset || {}).forEach((prop) =>
+                propSet.add(`${psetName}.${prop}`)
+              );
+            }
+          }
+        });
+        setAvailableProps(Array.from(propSet).sort());
+      }
+    }
+  }, [node.type]);
   // Return null for ifcNode type to prevent properties panel from rendering anything
   if (node.type === "ifcNode") {
     return null;
@@ -99,14 +123,34 @@ export function NodePropertyRenderer({
         <div className="space-y-4">
           <div className="space-y-2">
             <Label htmlFor="property">Property</Label>
-            <Input
-              id="property"
-              value={properties.property || ""}
-              onChange={(e) =>
-                setProperties({ ...properties, property: e.target.value })
-              }
-              placeholder="e.g. Type, Material, etc."
-            />
+            {availableProps.length > 0 ? (
+              <Select
+                value={properties.property || ""}
+                onValueChange={(value) =>
+                  setProperties({ ...properties, property: value })
+                }
+              >
+                <SelectTrigger id="property">
+                  <SelectValue placeholder="Select property" />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableProps.map((p) => (
+                    <SelectItem key={p} value={p}>
+                      {p}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <Input
+                id="property"
+                value={properties.property || ""}
+                onChange={(e) =>
+                  setProperties({ ...properties, property: e.target.value })
+                }
+                placeholder="e.g. Pset_WallCommon.FireRating"
+              />
+            )}
           </div>
           <div className="space-y-2">
             <Label htmlFor="operator">Operator</Label>

--- a/components/properties-panel/property-editors/filter-editor.tsx
+++ b/components/properties-panel/property-editors/filter-editor.tsx
@@ -1,8 +1,10 @@
 "use client"
 
+import { useEffect, useState } from "react"
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { getLastLoadedModel } from "@/lib/ifc-utils"
 
 interface FilterEditorProps {
   properties: {
@@ -15,16 +17,59 @@ interface FilterEditorProps {
 }
 
 export function FilterEditor({ properties, setProperties }: FilterEditorProps) {
+  const [availableProps, setAvailableProps] = useState<string[]>([]);
+
+  useEffect(() => {
+    const model = getLastLoadedModel();
+    if (model) {
+      const propSet = new Set<string>();
+      model.elements.forEach((el) => {
+        Object.keys(el.properties || {}).forEach((p) => propSet.add(p));
+        if (el.psets) {
+          for (const psetName in el.psets) {
+            const pset = el.psets[psetName];
+            Object.keys(pset || {}).forEach((prop) =>
+              propSet.add(`${psetName}.${prop}`)
+            );
+          }
+        }
+      });
+      setAvailableProps(Array.from(propSet).sort());
+    }
+  }, []);
+
   return (
     <div className="space-y-4">
       <div className="space-y-2">
         <Label htmlFor="property">Property</Label>
-        <Input
-          id="property"
-          value={properties.property || ""}
-          onChange={(e) => setProperties({ ...properties, property: e.target.value })}
-          placeholder="e.g. Type, Material, etc."
-        />
+        {availableProps.length > 0 ? (
+          <Select
+            value={properties.property || ""}
+            onValueChange={(value) =>
+              setProperties({ ...properties, property: value })
+            }
+          >
+            <SelectTrigger id="property">
+              <SelectValue placeholder="Select property" />
+            </SelectTrigger>
+            <SelectContent>
+              {availableProps.map((p) => (
+                <SelectItem key={p} value={p}>
+                  {p}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          <Input
+            id="property"
+            value={properties.property || ""}
+            onChange={(e) =>
+              setProperties({ ...properties, property: e.target.value })
+            }
+            placeholder="e.g. Pset_WallCommon.FireRating"
+          />
+        )}
       </div>
       <div className="space-y-2">
         <Label htmlFor="operator">Operator</Label>

--- a/lib/ifc-utils.ts
+++ b/lib/ifc-utils.ts
@@ -560,20 +560,26 @@ export async function extractGeometryWithGeom(
 
 // Filter elements by property
 export function filterElements(
-  elements: IfcElement[],
+  elements: IfcElement[] | IfcModel,
   property: string,
   operator: string,
   value: string
 ): IfcElement[] {
   console.log("Filtering elements:", property, operator, value);
 
+  const elementArray = Array.isArray(elements)
+    ? elements
+    : elements && (elements as IfcModel).elements
+    ? (elements as IfcModel).elements
+    : [];
+
   // Add a check for undefined or empty elements
-  if (!elements || elements.length === 0) {
+  if (!elementArray || elementArray.length === 0) {
     console.warn("No elements to filter");
     return [];
   }
 
-  return elements.filter((element) => {
+  return elementArray.filter((element) => {
     // Split property path (e.g., "Pset_WallCommon.FireRating")
     const propParts = property.split(".");
 


### PR DESCRIPTION
## Summary
- handle IfcModel input in `filterElements`
- list properties from the loaded model when editing filter nodes
- expose property list in standalone filter editor

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6877d935fd78832097626c674ba99ca8