### PR TITLE
Improve filter node property selection

### DIFF
--- a/components/properties-panel/node-property-renderer.tsx
+++ b/components/properties-panel/node-property-renderer.tsx
@@ -3,6 +3,8 @@
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { useEffect, useState } from "react";
+import { getModelPropertyNames } from "@/lib/ifc-utils";
 import {
   Select,
   SelectContent,
@@ -22,6 +24,11 @@ export function NodePropertyRenderer({
   properties,
   setProperties,
 }: NodePropertyRendererProps) {
+  const [modelProps, setModelProps] = useState<string[]>([]);
+
+  useEffect(() => {
+    setModelProps(getModelPropertyNames());
+  }, []);
   // Return null for ifcNode type to prevent properties panel from rendering anything
   if (node.type === "ifcNode") {
     return null;
@@ -101,12 +108,20 @@ export function NodePropertyRenderer({
             <Label htmlFor="property">Property</Label>
             <Input
               id="property"
+              list="model-properties"
               value={properties.property || ""}
               onChange={(e) =>
                 setProperties({ ...properties, property: e.target.value })
               }
-              placeholder="e.g. Type, Material, etc."
+              placeholder="e.g. Pset_WallCommon.FireRating"
             />
+            {modelProps.length > 0 && (
+              <datalist id="model-properties">
+                {modelProps.map((p) => (
+                  <option key={p} value={p} />
+                ))}
+              </datalist>
+            )}
           </div>
           <div className="space-y-2">
             <Label htmlFor="operator">Operator</Label>

--- a/components/properties-panel/property-editors/filter-editor.tsx
+++ b/components/properties-panel/property-editors/filter-editor.tsx
@@ -3,6 +3,8 @@
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { useEffect, useState } from "react"
+import { getModelPropertyNames } from "@/lib/ifc-utils"
 
 interface FilterEditorProps {
   properties: {
@@ -15,16 +17,29 @@ interface FilterEditorProps {
 }
 
 export function FilterEditor({ properties, setProperties }: FilterEditorProps) {
+  const [modelProps, setModelProps] = useState<string[]>([])
+
+  useEffect(() => {
+    setModelProps(getModelPropertyNames())
+  }, [])
   return (
     <div className="space-y-4">
       <div className="space-y-2">
         <Label htmlFor="property">Property</Label>
         <Input
           id="property"
+          list="model-properties"
           value={properties.property || ""}
           onChange={(e) => setProperties({ ...properties, property: e.target.value })}
-          placeholder="e.g. Type, Material, etc."
+          placeholder="e.g. Pset_WallCommon.FireRating"
         />
+        {modelProps.length > 0 && (
+          <datalist id="model-properties">
+            {modelProps.map((p) => (
+              <option key={p} value={p} />
+            ))}
+          </datalist>
+        )}
       </div>
       <div className="space-y-2">
         <Label htmlFor="operator">Operator</Label>

--- a/lib/ifc-utils.ts
+++ b/lib/ifc-utils.ts
@@ -71,6 +71,32 @@ export function getIfcFile(fileName: string): File | null {
   return ifcFileCache.get(fileName) || null;
 }
 
+// Get a list of unique property names available in the given model
+// If no model is provided, uses the last loaded model
+export function getModelPropertyNames(model?: IfcModel): string[] {
+  const current = model || getLastLoadedModel();
+  if (!current) return [];
+
+  const props = new Set<string>();
+
+  current.elements.forEach((el) => {
+    if (el.properties) {
+      Object.keys(el.properties).forEach((p) => props.add(p));
+    }
+
+    if (el.psets) {
+      for (const pset in el.psets) {
+        const psetProps = el.psets[pset];
+        for (const prop in psetProps) {
+          props.add(`${pset}.${prop}`);
+        }
+      }
+    }
+  });
+
+  return Array.from(props).sort();
+}
+
 // Worker management
 let ifcWorker: Worker | null = null;
 let isWorkerInitialized = false;

--- a/lib/workflow-executor.ts
+++ b/lib/workflow-executor.ts
@@ -269,8 +269,12 @@ export class WorkflowExecutor {
           console.warn(`No input provided to filter node ${nodeId}`);
           result = [];
         } else {
+          const elementsToFilter = Array.isArray(inputValues.input)
+            ? inputValues.input
+            : inputValues.input.elements;
+
           result = filterElements(
-            inputValues.input,
+            elementsToFilter || [],
             node.data.properties?.property || "",
             node.data.properties?.operator || "equals",
             node.data.properties?.value || ""


### PR DESCRIPTION
## Summary
- allow WorkflowExecutor filter node to accept model objects
- expose `getModelPropertyNames` for listing properties
- show available model properties when editing filter nodes
- support property suggestions in filter editor

## Testing
- `npm run lint` *(fails: setup prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_6877d935fd78832097626c674ba99ca8