### PR TITLE
Improve python script node

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ IFC Flow Map provides a graphical interface for viewing, filtering, transforming
   - 📊 **Analysis Node** - Perform analyses like clash detection
   - 👀 **Watch Node** - Monitor element values
   - ⚙️ **Parameter Node** - Define workflow parameters
+  - 🐍 **Python Script Node** - Execute custom Python on workflow data
 - 💾 **Workflow Storage** - Save and load workflows
 - ⚡ **Real-time Execution** - Execute workflows and see results immediately
 - ⌨️ **Keyboard Shortcuts** - Efficient workflow creation with keyboard shortcuts
@@ -88,6 +89,10 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 2. **Set Properties** - Modify existing properties or add new ones with the "Set" action
 3. **Connect Property Nodes** - Chain property operations by connecting nodes
 4. **Export Modified IFC** - Use the Export Node with "ifc" format to save your changes
+
+## 🐍 Python Node Example
+
+See [docs/python-node.md](docs/python-node.md) for an example script that groups elements and calculates averages using the Python Script node.
 
 ## 📚 Technical Details
 

--- a/components/dialogs/help-dialog.tsx
+++ b/components/dialogs/help-dialog.tsx
@@ -607,12 +607,31 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
                     <Button variant="outline" size="sm" className="w-full">
                       Load Example
                     </Button>
-                  </CardFooter>
-                </Card>
+                </CardFooter>
+              </Card>
 
-                <Card>
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-base">Data Export</CardTitle>
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">Python Aggregation</CardTitle>
+                  <CardDescription>
+                    Group elements and compute averages using a Python Script node
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="text-sm text-muted-foreground">
+                  <p>
+                    This example demonstrates running custom Python code inside a workflow.
+                  </p>
+                </CardContent>
+                <CardFooter className="pt-0">
+                  <Button variant="outline" size="sm" className="w-full">
+                    Load Example
+                  </Button>
+                </CardFooter>
+              </Card>
+
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">Data Export</CardTitle>
                     <CardDescription>
                       Export model data to various formats
                     </CardDescription>

--- a/components/nodes/python-script-node.tsx
+++ b/components/nodes/python-script-node.tsx
@@ -3,10 +3,12 @@
 import { memo, useState } from "react"
 import { Handle, Position, NodeProps, useReactFlow } from "reactflow"
 import { Code } from "lucide-react"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog"
+import { Textarea } from "@/components/ui/textarea"
 import { PythonScriptNodeData } from "./node-types"
 
 export const PythonScriptNode = memo(({ data, id, isConnectable }: NodeProps<PythonScriptNodeData>) => {
-  const [expanded, setExpanded] = useState(false)
+  const [open, setOpen] = useState(false)
   const { setNodes } = useReactFlow()
   const script = data.properties?.script || ""
   const consoleText = data.console || ""
@@ -22,33 +24,38 @@ export const PythonScriptNode = memo(({ data, id, isConnectable }: NodeProps<Pyt
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 border-2 border-orange-500 dark:border-orange-400 rounded-md w-60 shadow-md">
+    <Dialog open={open} onOpenChange={setOpen}>
       <div
-        className="bg-orange-500 text-white px-3 py-1 flex items-center justify-between cursor-pointer"
-        onClick={() => setExpanded(!expanded)}
+        onDoubleClick={() => setOpen(true)}
+        className="bg-white dark:bg-gray-800 border-2 border-orange-500 dark:border-orange-400 rounded-md w-48 shadow-md"
       >
-        <div className="flex items-center gap-2">
+        <div className="bg-orange-500 text-white px-3 py-1 flex items-center gap-2">
           <Code className="h-4 w-4" />
-          <div className="text-sm font-medium truncate" title={data.label}>{data.label}</div>
+          <div className="text-sm font-medium truncate" title={data.label}">{data.label}</div>
         </div>
-        <div className="text-xs">{expanded ? "Hide" : "Edit"}</div>
+        <div className="p-3 text-xs text-muted-foreground">Double-click to edit script</div>
+        <Handle type="target" position={Position.Left} id="input" style={{ background: "#555", width: 8, height: 8 }} isConnectable={isConnectable} />
+        <Handle type="source" position={Position.Right} id="output" style={{ background: "#555", width: 8, height: 8 }} isConnectable={isConnectable} />
       </div>
-      {expanded && (
-        <div className="p-2 text-xs space-y-2">
-          <textarea
-            className="w-full h-32 p-1 font-mono border rounded bg-gray-50 dark:bg-gray-900"
+
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Edit Python Script</DialogTitle>
+          <DialogDescription>Execute custom Python code on the input data.</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          <Textarea
             value={script}
             onChange={e => updateScript(e.target.value)}
             placeholder="# Write Python script here"
+            className="font-mono h-40"
           />
           <div className="h-24 overflow-auto bg-black text-green-300 font-mono p-1 rounded whitespace-pre-wrap">
             {consoleText || "Console output"}
           </div>
         </div>
-      )}
-      <Handle type="target" position={Position.Left} id="input" style={{ background: "#555", width: 8, height: 8 }} isConnectable={isConnectable} />
-      <Handle type="source" position={Position.Right} id="output" style={{ background: "#555", width: 8, height: 8 }} isConnectable={isConnectable} />
-    </div>
+      </DialogContent>
+    </Dialog>
   )
 })
 

--- a/docs/python-node.md
+++ b/docs/python-node.md
@@ -1,0 +1,61 @@
+# Python Script Node
+
+The Python Script node lets you run custom Python code as part of a workflow. It receives the incoming data as `input_data` and must assign the variable `result` which will be passed to the next node.
+
+Example workflow script:
+
+```python
+from collections import defaultdict
+import hashlib
+
+elements = input_data.get("elements", [])
+
+def get_storey_name(el):
+    for rel in el.get("ContainedInStructure", []):
+        relating = rel.get("RelatingStructure", {})
+        if relating.get("type") == "IfcBuildingStorey":
+            return relating.get("Name") or relating.get("GlobalId")
+    return "—"
+
+def checksum(guid):
+    if not guid:
+        return "n/a"
+    return hashlib.md5(guid.encode()).hexdigest()[:6]
+
+def is_load_bearing(eltype):
+    return eltype in ["IfcWall", "IfcColumn", "IfcBeam"]
+
+agg = defaultdict(lambda: {"Count": 0, "Heights": [], "Widths": []})
+
+for el in elements:
+    if not isinstance(el, dict):
+        continue
+    eltype = el.get("type", "???")
+    pred = el.get("PredefinedType") or el.get("ObjectType") or "—"
+    storey = get_storey_name(el)
+    key = f"{eltype} | {pred} | {storey}"
+
+    agg[key]["Count"] += 1
+    if "OverallHeight" in el:
+        agg[key]["Heights"].append(el["OverallHeight"])
+    if "OverallWidth" in el:
+        agg[key]["Widths"].append(el["OverallWidth"])
+    agg[key]["LastGUID"] = checksum(el.get("GlobalId"))
+
+# Convert to Watch-friendly format
+result = []
+for k, v in sorted(agg.items()):
+    eltype, pred, storey = k.split(" | ")
+    avg_h = round(sum(v["Heights"]) / len(v["Heights"])) if v["Heights"] else None
+    avg_w = round(sum(v["Widths"]) / len(v["Widths"])) if v["Widths"] else None
+    result.append({
+        "Type": eltype,
+        "Predefined": pred,
+        "Storey": storey,
+        "Count": v["Count"],
+        "AvgHeight": avg_h,
+        "AvgWidth": avg_w,
+        "Checksum": v["LastGUID"],
+        "LoadBearing?": "✓" if is_load_bearing(eltype) else ""
+    })
+```


### PR DESCRIPTION
## Summary
- adjust Python Script node styling and expose double-click editor dialog
- add Python node to feature list in README
- document example Python script for aggregation
- showcase Python Aggregation example in help dialog

## Testing
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6877ba6cab5c8320847c1afad5e12017