### PR TITLE
Add Python node with IfcOpenShell support

### DIFF
--- a/components/nodes/index.ts
+++ b/components/nodes/index.ts
@@ -12,6 +12,7 @@ import { RelationshipNode } from "./relationship-node"
 import { AnalysisNode } from "./analysis-node"
 import { WatchNode } from "./watch-node"
 import { ParameterNode } from "./parameter-node"
+import { PythonNode } from "./python-node"
 
 // Define custom node types
 export const nodeTypes = {
@@ -29,6 +30,7 @@ export const nodeTypes = {
   analysisNode: AnalysisNode,
   watchNode: WatchNode,
   parameterNode: ParameterNode,
+  pythonNode: PythonNode,
 }
 
 export {
@@ -46,5 +48,6 @@ export {
   AnalysisNode,
   WatchNode,
   ParameterNode,
+  PythonNode,
 }
 

--- a/components/nodes/node-types.ts
+++ b/components/nodes/node-types.ts
@@ -72,6 +72,15 @@ export interface ParameterNodeData extends BaseNodeData {
     };
 }
 
+// Python node data
+export interface PythonNodeData extends BaseNodeData {
+    properties?: {
+        code?: string;
+        [key: string]: any;
+    };
+    output?: any;
+}
+
 // Property node data
 export interface PropertyNodeData extends BaseNodeData {
     properties?: {

--- a/components/nodes/python-node.tsx
+++ b/components/nodes/python-node.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { memo } from "react";
+import { Handle, Position, type NodeProps } from "reactflow";
+import { FileCode } from "lucide-react";
+import { NodeLoadingIndicator } from "./node-loading-indicator";
+import { PythonNodeData as BasePythonNodeData } from "./node-types";
+
+interface ExtendedPythonNodeData extends BasePythonNodeData {
+  isLoading?: boolean;
+  error?: string | null;
+  output?: any;
+}
+
+export const PythonNode = memo(({ data, isConnectable }: NodeProps<ExtendedPythonNodeData>) => {
+  return (
+    <div className="bg-white dark:bg-gray-800 border-2 border-purple-500 dark:border-purple-400 rounded-md w-48 shadow-md">
+      <div className="bg-purple-500 text-white px-3 py-1 flex items-center gap-2">
+        <FileCode className="h-4 w-4" />
+        <div className="text-sm font-medium truncate">{data.label || "Python"}</div>
+      </div>
+      <NodeLoadingIndicator
+        isLoading={data.isLoading || false}
+        message="Running Python..."
+      />
+      {!data.isLoading && data.error && (
+        <div className="p-3 text-xs text-red-500 break-words">Error: {data.error}</div>
+      )}
+      {!data.isLoading && !data.error && data.output && (
+        <div className="p-3 text-xs break-words">
+          {typeof data.output === "string" ? data.output : JSON.stringify(data.output)}
+        </div>
+      )}
+      <Handle
+        type="target"
+        position={Position.Left}
+        id="input"
+        style={{ background: "#555", width: 8, height: 8 }}
+        isConnectable={isConnectable}
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        id="output"
+        style={{ background: "#555", width: 8, height: 8 }}
+        isConnectable={isConnectable}
+      />
+    </div>
+  );
+});
+
+PythonNode.displayName = "PythonNode";

--- a/lib/ifc-utils.ts
+++ b/lib/ifc-utils.ts
@@ -186,6 +186,11 @@ export async function initializeWorker(): Promise<void> {
           workerPromiseResolvers.get(messageId)!.resolve(data.data);
           workerPromiseResolvers.delete(messageId);
         }
+      } else if (type === "pythonResult") {
+        if (messageId && workerPromiseResolvers.has(messageId)) {
+          workerPromiseResolvers.get(messageId)!.resolve(data);
+          workerPromiseResolvers.delete(messageId);
+        }
       }
       // Progress messages don't resolve promises
     };
@@ -1774,4 +1779,70 @@ export function downloadExportedFile(
   a.click();
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
+}
+
+// Execute custom Python code using the Pyodide worker and IfcOpenShell
+export async function runPythonScript(
+  model: IfcModel,
+  code: string,
+  onProgress?: (progress: number, message?: string) => void
+): Promise<any> {
+  await initializeWorker();
+  if (!ifcWorker) {
+    throw new Error("IFC worker is not available for Python execution");
+  }
+
+  const file = getIfcFile(model.name);
+  if (!file) {
+    throw new Error(`Could not retrieve cached file object for ${model.name}`);
+  }
+
+  const arrayBuffer = await file.arrayBuffer();
+  const messageId = `py_${Date.now()}_${Math.random().toString(36).substring(2,9)}`;
+
+  const resultPromise = new Promise<any>((resolve, reject) => {
+    const progressHandler = (event: MessageEvent) => {
+      const data = event.data;
+      if (data.type === "progress" && data.messageId === messageId && onProgress) {
+        onProgress(data.percentage, data.message);
+      }
+    };
+    if (onProgress) ifcWorker!.addEventListener("message", progressHandler);
+
+    const timeout = setTimeout(() => {
+      if (workerPromiseResolvers.has(messageId)) {
+        reject(new Error("Worker timeout during Python execution"));
+        workerPromiseResolvers.delete(messageId);
+        if (onProgress) ifcWorker!.removeEventListener("message", progressHandler);
+      }
+    }, 60000);
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      if (onProgress) ifcWorker!.removeEventListener("message", progressHandler);
+      workerPromiseResolvers.delete(messageId);
+    };
+
+    workerPromiseResolvers.set(messageId, {
+      resolve: (data: any) => {
+        cleanup();
+        resolve(data);
+      },
+      reject: (error: any) => {
+        cleanup();
+        reject(error);
+      },
+    });
+
+    ifcWorker!.postMessage(
+      {
+        action: "runPython",
+        messageId,
+        data: { code, arrayBuffer },
+      },
+      [arrayBuffer]
+    );
+  });
+
+  return resultPromise;
 }

--- a/lib/workflow-executor.ts
+++ b/lib/workflow-executor.ts
@@ -14,6 +14,7 @@ import {
   IfcModel,
   getLastLoadedModel,
   extractGeometryWithGeom,
+  runPythonScript,
 } from "@/lib/ifc-utils";
 
 // Add TypeScript interfaces at the top of the file
@@ -796,6 +797,39 @@ export class WorkflowExecutor {
       case "parameterNode":
         // Parameter
         result = node.data.properties?.value || "";
+        break;
+
+      case "pythonNode":
+        if (!inputValues.input) {
+          console.warn(`No input provided to python node ${nodeId}`);
+          result = null;
+        } else {
+          const modelInput = inputValues.input as IfcModel;
+          try {
+            result = await runPythonScript(
+              modelInput,
+              node.data.properties?.code || "",
+              (p, m) => {
+                this.updateNodeDataInList(nodeId, {
+                  ...node.data,
+                  isLoading: true,
+                });
+              }
+            );
+            this.updateNodeDataInList(nodeId, {
+              ...node.data,
+              isLoading: false,
+              output: result,
+            });
+          } catch (error) {
+            this.updateNodeDataInList(nodeId, {
+              ...node.data,
+              isLoading: false,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            throw error;
+          }
+        }
         break;
 
       case "viewerNode":

--- a/public/ifcWorker.js
+++ b/public/ifcWorker.js
@@ -124,6 +124,11 @@ self.onmessage = async (event) => {
         await handleExtractQuantities(data, messageId);
         break;
 
+      case "runPython":
+        console.log("Executing custom Python code...");
+        await handleRunPython(data, messageId);
+        break;
+
       default:
         throw new Error(`Unknown action: ${action}`);
     }
@@ -1862,5 +1867,59 @@ except Exception as e:
       message: `Error extracting quantities: ${error.message}`,
       messageId,
     });
+  }
+}
+
+// Execute arbitrary Python code
+async function handleRunPython(data, messageId) {
+  try {
+    await initPyodide();
+
+    const { code, arrayBuffer } = data;
+    if (arrayBuffer && arrayBuffer instanceof ArrayBuffer) {
+      try {
+        pyodide.FS.writeFile("model.ifc", new Uint8Array(arrayBuffer));
+      } catch (err) {
+        console.error("Failed writing IFC buffer", err);
+      }
+    }
+
+    const namespace = pyodide.globals.get("dict")();
+    namespace.set("user_code", code);
+
+    const pythonWrapper = `
+import json, traceback, ifcopenshell, os
+result = None
+success = False
+try:
+    if os.path.exists('model.ifc'):
+        ifc_file = ifcopenshell.open('model.ifc')
+    exec(user_code, globals())
+    success = True
+    if 'result' in globals():
+        result_json = json.dumps(result)
+    else:
+        result_json = json.dumps(None)
+except Exception as e:
+    result_json = json.dumps({'error': str(e), 'trace': traceback.format_exc()})
+    success = False
+`;
+
+    await pyodide.runPythonAsync(pythonWrapper, { globals: namespace });
+
+    const success = namespace.get("success");
+    const resultJson = namespace.get("result_json");
+    namespace.destroy();
+
+    if (!success) {
+      const err = JSON.parse(resultJson);
+      self.postMessage({ type: "error", message: err.error, stack: err.trace, messageId });
+      return;
+    }
+
+    const output = resultJson ? JSON.parse(resultJson) : null;
+    self.postMessage({ type: "pythonResult", data: output, messageId });
+  } catch (error) {
+    self.postMessage({ type: "error", message: error.message, messageId });
   }
 }


### PR DESCRIPTION
## Summary
- add `PythonNode` component
- support Python node data in node types
- enable python node in node registry
- expose `runPythonScript` via ifc-utils and worker
- update workflow executor to handle python nodes
- implement worker action `runPython`

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_687b8271442c83209e241a2e5ab29009

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a Python node that allows users to execute custom Python scripts within workflows.
  * Added support for running Python code on IFC models with real-time progress updates and error handling.
  * Enhanced workflow capabilities to include dynamic Python script execution and output display.

* **Bug Fixes**
  * Improved error reporting for Python script execution failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->