### PR TITLE
Remove unused settings and connect snap-to-grid

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -120,6 +120,7 @@ function FlowWithProvider() {
 
   // View settings
   const [showGrid, setShowGrid] = useState(settings.viewer.showGrid);
+  const [snapToGrid, setSnapToGrid] = useState(settings.viewer.snapToGrid);
   const [showMinimap, setShowMinimap] = useState(false);
 
   // Current workflow state
@@ -175,6 +176,11 @@ function FlowWithProvider() {
   useEffect(() => {
     setShowGrid(settings.viewer.showGrid);
   }, [settings.viewer.showGrid]);
+
+  // Apply snap to grid setting
+  useEffect(() => {
+    setSnapToGrid(settings.viewer.snapToGrid);
+  }, [settings.viewer.snapToGrid]);
 
   // Set up auto-save
   useEffect(() => {
@@ -1589,7 +1595,7 @@ function FlowWithProvider() {
                 }
               }}
               nodeTypes={nodeTypes}
-              snapToGrid
+              snapToGrid={snapToGrid}
               snapGrid={[15, 15]}
               minZoom={0.1}
               maxZoom={2}

--- a/components/dialogs/settings-dialog.tsx
+++ b/components/dialogs/settings-dialog.tsx
@@ -6,7 +6,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+
 import { Slider } from "@/components/ui/slider"
 import { useAppSettings } from "@/lib/settings-manager"
 import { Monitor, Moon, Sun } from "lucide-react"
@@ -18,7 +18,7 @@ interface SettingsDialogProps {
 
 export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   const [activeTab, setActiveTab] = useState("general")
-  const { settings, updateGeneralSettings, updateViewerSettings, updatePerformanceSettings, resetSettings } =
+  const { settings, updateGeneralSettings, updateViewerSettings, resetSettings } =
     useAppSettings()
 
   return (
@@ -29,10 +29,9 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
           <DialogDescription>Configure application settings and preferences.</DialogDescription>
         </DialogHeader>
         <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList className="grid grid-cols-3">
+          <TabsList className="grid grid-cols-2">
             <TabsTrigger value="general">General</TabsTrigger>
             <TabsTrigger value="viewer">Viewer</TabsTrigger>
-            <TabsTrigger value="performance">Performance</TabsTrigger>
           </TabsList>
           <TabsContent value="general" className="space-y-4 py-4">
             <div className="space-y-2">
@@ -114,62 +113,6 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                 />
               </div>
               <p className="text-sm text-muted-foreground">Automatically align nodes to the grid when moving them.</p>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="grid-size">Grid size</Label>
-              <div className="flex items-center gap-2">
-                <Slider
-                  id="grid-size"
-                  min={5}
-                  max={50}
-                  step={5}
-                  value={[settings.viewer.gridSize]}
-                  onValueChange={(value) => updateViewerSettings({ gridSize: value[0] })}
-                  className="flex-1"
-                />
-                <span className="w-12 text-center">{settings.viewer.gridSize}px</span>
-              </div>
-            </div>
-          </TabsContent>
-          <TabsContent value="performance" className="space-y-4 py-4">
-            <div className="space-y-2">
-              <Label htmlFor="max-nodes">Maximum nodes</Label>
-              <div className="flex items-center gap-2">
-                <Slider
-                  id="max-nodes"
-                  min={100}
-                  max={5000}
-                  step={100}
-                  value={[settings.performance.maxNodes]}
-                  onValueChange={(value) => updatePerformanceSettings({ maxNodes: value[0] })}
-                  className="flex-1"
-                />
-                <span className="w-16 text-center">{settings.performance.maxNodes}</span>
-              </div>
-              <p className="text-sm text-muted-foreground">
-                Maximum number of nodes allowed in a workflow. Higher values may impact performance.
-              </p>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="render-quality">Render quality</Label>
-              <Select
-                value={settings.performance.renderQuality}
-                onValueChange={(value) =>
-                  updatePerformanceSettings({ renderQuality: value as "low" | "medium" | "high" })
-                }
-              >
-                <SelectTrigger id="render-quality">
-                  <SelectValue placeholder="Select quality" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="low">Low</SelectItem>
-                  <SelectItem value="medium">Medium</SelectItem>
-                  <SelectItem value="high">High</SelectItem>
-                </SelectContent>
-              </Select>
-              <p className="text-sm text-muted-foreground">
-                Higher quality settings may impact performance on complex models.
-              </p>
             </div>
           </TabsContent>
         </Tabs>

--- a/components/flow-canvas.tsx
+++ b/components/flow-canvas.tsx
@@ -29,6 +29,7 @@ interface FlowCanvasProps {
   onNodeClick: (event: any, node: any) => void;
   isFileDragging: boolean;
   showGrid: boolean;
+  snapToGrid: boolean;
   showMinimap: boolean;
   currentWorkflow: any;
 }
@@ -43,6 +44,7 @@ export function FlowCanvas({
   onNodeClick,
   isFileDragging,
   showGrid,
+  snapToGrid,
   showMinimap,
   currentWorkflow,
 }: FlowCanvasProps) {
@@ -279,7 +281,7 @@ export function FlowCanvas({
         onDragOver={onDragOver}
         onNodeClick={onNodeClick}
         nodeTypes={nodeTypes}
-        snapToGrid
+        snapToGrid={snapToGrid}
         snapGrid={[15, 15]}
         minZoom={0.1}
         maxZoom={2}

--- a/lib/settings-manager.ts
+++ b/lib/settings-manager.ts
@@ -11,11 +11,6 @@ export interface AppSettings {
   viewer: {
     showGrid: boolean
     snapToGrid: boolean
-    gridSize: number
-  }
-  performance: {
-    maxNodes: number
-    renderQuality: "low" | "medium" | "high"
   }
 }
 
@@ -29,11 +24,6 @@ export const defaultSettings: AppSettings = {
   viewer: {
     showGrid: true,
     snapToGrid: true,
-    gridSize: 15,
-  },
-  performance: {
-    maxNodes: 1000,
-    renderQuality: "medium",
   },
 }
 
@@ -96,14 +86,6 @@ export function useAppSettings() {
     saveSettings(updated)
   }
 
-  const updatePerformanceSettings = (performanceSettings: Partial<AppSettings["performance"]>) => {
-    const updated = {
-      ...settings,
-      performance: { ...settings.performance, ...performanceSettings },
-    }
-    setSettings(updated)
-    saveSettings(updated)
-  }
 
   const resetSettings = () => {
     setSettings(defaultSettings)
@@ -115,7 +97,6 @@ export function useAppSettings() {
     updateSettings,
     updateGeneralSettings,
     updateViewerSettings,
-    updatePerformanceSettings,
     resetSettings,
   }
 }


### PR DESCRIPTION
## Summary
- clean up Settings dialog
- drop unused performance options
- remove grid size control
- wire snap-to-grid setting into canvas

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run build` *(cancelled due to long build)*

------
https://chatgpt.com/codex/tasks/task_e_687b97248b788320b76ab54c5b10e18d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic control for snap-to-grid behavior in the flow view, allowing it to respond to user settings.

* **Removals**
  * Removed the "performance" tab and related options (maximum nodes, render quality) from the settings dialog.
  * Removed the grid size slider from the viewer settings.

* **Improvements**
  * Updated the flow canvas to support runtime toggling of grid snapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->