### PR TITLE
Clean up settings dialog

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1589,8 +1589,8 @@ function FlowWithProvider() {
                 }
               }}
               nodeTypes={nodeTypes}
-              snapToGrid
-              snapGrid={[15, 15]}
+              snapToGrid={settings.viewer.snapToGrid}
+              snapGrid={[settings.viewer.gridSize, settings.viewer.gridSize]}
               minZoom={0.1}
               maxZoom={2}
               proOptions={{ hideAttribution: true }}
@@ -1604,7 +1604,7 @@ function FlowWithProvider() {
               nodesDraggable={!focusedViewerId}
             >
               <Controls />
-              {showGrid && <Background color="#aaa" gap={16} />}
+              {showGrid && <Background color="#aaa" gap={settings.viewer.gridSize} />}
               {showMinimap && <MiniMap />}
               <Panel position="bottom-right">
                 <div className="bg-card rounded-md p-2 text-xs text-muted-foreground">

--- a/components/dialogs/settings-dialog.tsx
+++ b/components/dialogs/settings-dialog.tsx
@@ -18,7 +18,7 @@ interface SettingsDialogProps {
 
 export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   const [activeTab, setActiveTab] = useState("general")
-  const { settings, updateGeneralSettings, updateViewerSettings, updatePerformanceSettings, resetSettings } =
+  const { settings, updateGeneralSettings, updateViewerSettings, resetSettings } =
     useAppSettings()
 
   return (
@@ -29,10 +29,9 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
           <DialogDescription>Configure application settings and preferences.</DialogDescription>
         </DialogHeader>
         <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList className="grid grid-cols-3">
+          <TabsList className="grid grid-cols-2">
             <TabsTrigger value="general">General</TabsTrigger>
             <TabsTrigger value="viewer">Viewer</TabsTrigger>
-            <TabsTrigger value="performance">Performance</TabsTrigger>
           </TabsList>
           <TabsContent value="general" className="space-y-4 py-4">
             <div className="space-y-2">
@@ -129,47 +128,6 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                 />
                 <span className="w-12 text-center">{settings.viewer.gridSize}px</span>
               </div>
-            </div>
-          </TabsContent>
-          <TabsContent value="performance" className="space-y-4 py-4">
-            <div className="space-y-2">
-              <Label htmlFor="max-nodes">Maximum nodes</Label>
-              <div className="flex items-center gap-2">
-                <Slider
-                  id="max-nodes"
-                  min={100}
-                  max={5000}
-                  step={100}
-                  value={[settings.performance.maxNodes]}
-                  onValueChange={(value) => updatePerformanceSettings({ maxNodes: value[0] })}
-                  className="flex-1"
-                />
-                <span className="w-16 text-center">{settings.performance.maxNodes}</span>
-              </div>
-              <p className="text-sm text-muted-foreground">
-                Maximum number of nodes allowed in a workflow. Higher values may impact performance.
-              </p>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="render-quality">Render quality</Label>
-              <Select
-                value={settings.performance.renderQuality}
-                onValueChange={(value) =>
-                  updatePerformanceSettings({ renderQuality: value as "low" | "medium" | "high" })
-                }
-              >
-                <SelectTrigger id="render-quality">
-                  <SelectValue placeholder="Select quality" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="low">Low</SelectItem>
-                  <SelectItem value="medium">Medium</SelectItem>
-                  <SelectItem value="high">High</SelectItem>
-                </SelectContent>
-              </Select>
-              <p className="text-sm text-muted-foreground">
-                Higher quality settings may impact performance on complex models.
-              </p>
             </div>
           </TabsContent>
         </Tabs>

--- a/components/flow-canvas.tsx
+++ b/components/flow-canvas.tsx
@@ -15,6 +15,7 @@ import "reactflow/dist/style.css";
 import { FileUp } from "lucide-react";
 import { loadIfcFile } from "@/lib/ifc";
 import { useToast } from "@/hooks/use-toast";
+import { useAppSettings } from "@/lib/settings-manager";
 
 // Import node types
 import { nodeTypes } from "@/components/nodes";
@@ -48,6 +49,7 @@ export function FlowCanvas({
 }: FlowCanvasProps) {
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const { toast } = useToast();
+  const { settings } = useAppSettings();
   const reactFlowInstance = useReactFlow();
 
   // Handle dropping new nodes from the sidebar
@@ -279,13 +281,13 @@ export function FlowCanvas({
         onDragOver={onDragOver}
         onNodeClick={onNodeClick}
         nodeTypes={nodeTypes}
-        snapToGrid
-        snapGrid={[15, 15]}
+        snapToGrid={settings.viewer.snapToGrid}
+        snapGrid={[settings.viewer.gridSize, settings.viewer.gridSize]}
         minZoom={0.1}
         maxZoom={2}
       >
         <Controls />
-        {showGrid && <Background color="#aaa" gap={16} />}
+        {showGrid && <Background color="#aaa" gap={settings.viewer.gridSize} />}
         {showMinimap && <MiniMap />}
         <Panel position="bottom-right">
           <div className="bg-card rounded-md p-2 text-xs text-muted-foreground">

--- a/lib/settings-manager.ts
+++ b/lib/settings-manager.ts
@@ -13,10 +13,6 @@ export interface AppSettings {
     snapToGrid: boolean
     gridSize: number
   }
-  performance: {
-    maxNodes: number
-    renderQuality: "low" | "medium" | "high"
-  }
 }
 
 // Default settings
@@ -30,10 +26,6 @@ export const defaultSettings: AppSettings = {
     showGrid: true,
     snapToGrid: true,
     gridSize: 15,
-  },
-  performance: {
-    maxNodes: 1000,
-    renderQuality: "medium",
   },
 }
 
@@ -96,14 +88,6 @@ export function useAppSettings() {
     saveSettings(updated)
   }
 
-  const updatePerformanceSettings = (performanceSettings: Partial<AppSettings["performance"]>) => {
-    const updated = {
-      ...settings,
-      performance: { ...settings.performance, ...performanceSettings },
-    }
-    setSettings(updated)
-    saveSettings(updated)
-  }
 
   const resetSettings = () => {
     setSettings(defaultSettings)
@@ -115,7 +99,6 @@ export function useAppSettings() {
     updateSettings,
     updateGeneralSettings,
     updateViewerSettings,
-    updatePerformanceSettings,
     resetSettings,
   }
 }


### PR DESCRIPTION
## Summary
- remove unused performance settings
- wire up grid size settings to ReactFlow
- update settings manager

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_687b97248b788320b76ab54c5b10e18d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grid snapping and background grid gap in the flow canvas are now dynamically adjustable based on user settings.

* **Bug Fixes**
  * Grid size and snapping behavior now accurately reflect user preferences instead of using fixed values.

* **Chores**
  * Removed the "Performance" tab and all related options from the settings dialog and app settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->