### PR TITLE
Add mobile-friendly layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,6 +28,8 @@ import { FilterNode } from "@/components/nodes/filter-node";
 import { TransformNode } from "@/components/nodes/transform-node";
 import { ViewerNode } from "@/components/nodes/viewer-node";
 import { AppMenubar } from "@/components/menubar";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { QuantityNode } from "@/components/nodes/quantity-node";
 import { PropertyNode } from "@/components/nodes/property-node";
 import { ClassificationNode } from "@/components/nodes/classification-node";
@@ -117,6 +119,8 @@ function FlowWithProvider() {
   const { shortcuts } = useKeyboardShortcuts();
   const { settings } = useAppSettings();
   const { theme, setTheme } = useTheme();
+  const isMobile = useIsMobile();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   // View settings
   const [showGrid, setShowGrid] = useState(settings.viewer.showGrid);
@@ -1520,10 +1524,18 @@ function FlowWithProvider() {
 
   return (
     <div className="flex h-screen w-full bg-background">
-      <Sidebar
-        onLoadWorkflow={handleLoadWorkflow}
-        getFlowObject={getFlowObject}
-      />
+      {isMobile ? (
+        <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
+          <SheetContent side="left" className="p-0 w-72">
+            <Sidebar
+              onLoadWorkflow={handleLoadWorkflow}
+              getFlowObject={getFlowObject}
+            />
+          </SheetContent>
+        </Sheet>
+      ) : (
+        <Sidebar onLoadWorkflow={handleLoadWorkflow} getFlowObject={getFlowObject} />
+      )}
       <div className="flex flex-col flex-1">
         <AppMenubar
           onOpenFile={handleOpenFile}
@@ -1550,6 +1562,7 @@ function FlowWithProvider() {
           onCut={handleCut}
           onPaste={handlePaste}
           onDelete={handleDelete}
+          onToggleSidebar={() => setSidebarOpen(true)}
         />
         <div className={`flex-1 h-full relative`} ref={reactFlowWrapper}>
           <ViewerFocusProvider

--- a/components/menubar.tsx
+++ b/components/menubar.tsx
@@ -16,7 +16,7 @@ import {
   MenubarCheckboxItem,
 } from "@/components/ui/menubar";
 import { Button } from "@/components/ui/button";
-import { Play, Pause, Check } from "lucide-react";
+import { Play, Pause, Check, Menu, MoreVertical } from "lucide-react";
 import { OpenFileDialog } from "@/components/dialogs/open-file-dialog";
 import { SaveWorkflowDialog } from "@/components/dialogs/save-workflow-dialog";
 import { SettingsDialog } from "@/components/dialogs/settings-dialog";
@@ -24,12 +24,14 @@ import { HelpDialog } from "@/components/dialogs/help-dialog";
 import { AboutDialog } from "@/components/dialogs/about-dialog";
 import { WorkflowLibrary } from "@/components/workflow-library";
 import { useToast } from "@/hooks/use-toast";
+import { useIsMobile } from "@/hooks/use-mobile";
 import type { Workflow } from "@/lib/workflow-storage";
 import {
   formatKeyCombination,
   useKeyboardShortcuts,
 } from "@/lib/keyboard-shortcuts";
 import { ReactFlowInstance } from "reactflow";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
 
 // Define proper types for the component props
 interface AppMenubarProps {
@@ -55,6 +57,7 @@ interface AppMenubarProps {
   onCut: () => void;
   onPaste: () => void;
   onDelete: () => void;
+  onToggleSidebar: () => void;
 }
 
 export function AppMenubar({
@@ -80,6 +83,7 @@ export function AppMenubar({
   onCut,
   onPaste,
   onDelete,
+  onToggleSidebar,
 }: AppMenubarProps) {
   const [openFileDialogOpen, setOpenFileDialogOpen] = useState(false);
   const [saveWorkflowDialogOpen, setSaveWorkflowDialogOpen] = useState(false);
@@ -87,6 +91,8 @@ export function AppMenubar({
   const [settingsDialogOpen, setSettingsDialogOpen] = useState(false);
   const [helpDialogOpen, setHelpDialogOpen] = useState(false);
   const [aboutDialogOpen, setAboutDialogOpen] = useState(false);
+  const isMobile = useIsMobile();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const { toast } = useToast();
   const { shortcuts } = useKeyboardShortcuts();
   const { theme, setTheme } = useTheme();
@@ -250,224 +256,238 @@ export function AppMenubar({
     setShowMinimap(!showMinimap);
   };
 
-  return (
-    <>
-      <div className="flex items-center justify-between border-b p-1 bg-card">
-        <Menubar className="border-none">
-          <MenubarMenu>
-            <MenubarTrigger>File</MenubarTrigger>
-            <MenubarContent>
-              <MenubarItem
-                onClick={() => setOpenFileDialogOpen(true)}
-                data-open-file-dialog-trigger
-              >
-                Open IFC File
-                <MenubarShortcut>
-                  {getShortcutDisplay("open-file")}
-                </MenubarShortcut>
-              </MenubarItem>
-              <MenubarItem
-                onClick={() => setSaveWorkflowDialogOpen(true)}
-                data-save-workflow-dialog-trigger
-              >
-                Save Workflow
-                <MenubarShortcut>
-                  {getShortcutDisplay("save-workflow")}
-                </MenubarShortcut>
-              </MenubarItem>
-              <MenubarItem
-                onClick={() => setWorkflowLibraryOpen(true)}
-                data-workflow-library-trigger
-              >
-                Open Workflow Library
-                <MenubarShortcut>
-                  {getShortcutDisplay("open-workflow-library")}
-                </MenubarShortcut>
-              </MenubarItem>
-            </MenubarContent>
-          </MenubarMenu>
+  const MenuContent = () => (
+    <Menubar className="border-none flex-col md:flex-row">
+      <MenubarMenu>
+        <MenubarTrigger>File</MenubarTrigger>
+        <MenubarContent>
+          <MenubarItem
+            onClick={() => setOpenFileDialogOpen(true)}
+            data-open-file-dialog-trigger
+          >
+            Open IFC File
+            <MenubarShortcut>{getShortcutDisplay("open-file")}</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem
+            onClick={() => setSaveWorkflowDialogOpen(true)}
+            data-save-workflow-dialog-trigger
+          >
+            Save Workflow
+            <MenubarShortcut>{getShortcutDisplay("save-workflow")}</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem
+            onClick={() => setWorkflowLibraryOpen(true)}
+            data-workflow-library-trigger
+          >
+            Open Workflow Library
+            <MenubarShortcut>{getShortcutDisplay("open-workflow-library")}</MenubarShortcut>
+          </MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
 
-          <MenubarMenu>
-            <MenubarTrigger>Edit</MenubarTrigger>
-            <MenubarContent>
-              <MenubarItem onClick={handleUndo} disabled={!canUndo}>
-                Undo
-                <MenubarShortcut>{getShortcutDisplay("undo")}</MenubarShortcut>
-              </MenubarItem>
-              <MenubarItem onClick={handleRedo} disabled={!canRedo}>
-                Redo
-                <MenubarShortcut>{getShortcutDisplay("redo")}</MenubarShortcut>
-              </MenubarItem>
-              <MenubarSeparator />
-              <MenubarItem onClick={onCut}>
-                Cut
-                <MenubarShortcut>{getShortcutDisplay("cut")}</MenubarShortcut>
-              </MenubarItem>
-              <MenubarItem onClick={onCopy}>
-                Copy
-                <MenubarShortcut>{getShortcutDisplay("copy")}</MenubarShortcut>
-              </MenubarItem>
-              <MenubarItem onClick={onPaste}>
-                Paste
-                <MenubarShortcut>{getShortcutDisplay("paste")}</MenubarShortcut>
-              </MenubarItem>
-              <MenubarSeparator />
-              <MenubarItem onClick={onSelectAll}>
-                Select All
-                <MenubarShortcut>
-                  {getShortcutDisplay("select-all")}
-                </MenubarShortcut>
-              </MenubarItem>
-              <MenubarItem onClick={onDelete}>
-                Delete Selected
-                <MenubarShortcut>
-                  {getShortcutDisplay("delete")}
-                </MenubarShortcut>
-              </MenubarItem>
-            </MenubarContent>
-          </MenubarMenu>
+      <MenubarMenu>
+        <MenubarTrigger>Edit</MenubarTrigger>
+        <MenubarContent>
+          <MenubarItem onClick={handleUndo} disabled={!canUndo}>
+            Undo
+            <MenubarShortcut>{getShortcutDisplay("undo")}</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem onClick={handleRedo} disabled={!canRedo}>
+            Redo
+            <MenubarShortcut>{getShortcutDisplay("redo")}</MenubarShortcut>
+          </MenubarItem>
+          <MenubarSeparator />
+          <MenubarItem onClick={onCut}>
+            Cut
+            <MenubarShortcut>{getShortcutDisplay("cut")}</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem onClick={onCopy}>
+            Copy
+            <MenubarShortcut>{getShortcutDisplay("copy")}</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem onClick={onPaste}>
+            Paste
+            <MenubarShortcut>{getShortcutDisplay("paste")}</MenubarShortcut>
+          </MenubarItem>
+          <MenubarSeparator />
+          <MenubarItem onClick={onSelectAll}>
+            Select All
+            <MenubarShortcut>{getShortcutDisplay("select-all")}</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem onClick={onDelete}>
+            Delete Selected
+            <MenubarShortcut>{getShortcutDisplay("delete")}</MenubarShortcut>
+          </MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
 
-          <MenubarMenu>
-            <MenubarTrigger>View</MenubarTrigger>
-            <MenubarContent>
-              <MenubarItem onClick={handleZoomIn}>
-                Zoom In
-                <MenubarShortcut>
-                  {getShortcutDisplay("zoom-in")}
-                </MenubarShortcut>
-              </MenubarItem>
-              <MenubarItem onClick={handleZoomOut}>
-                Zoom Out
-                <MenubarShortcut>
-                  {getShortcutDisplay("zoom-out")}
-                </MenubarShortcut>
-              </MenubarItem>
-              <MenubarItem onClick={handleFitView}>
-                Fit View
-                <MenubarShortcut>
-                  {getShortcutDisplay("fit-view")}
-                </MenubarShortcut>
-              </MenubarItem>
-              <MenubarSeparator />
-              <MenubarCheckboxItem
-                checked={showGrid}
-                onCheckedChange={handleToggleGrid}
-              >
-                Show Grid
-                <MenubarShortcut>
-                  {getShortcutDisplay("toggle-grid")}
-                </MenubarShortcut>
-              </MenubarCheckboxItem>
-              <MenubarCheckboxItem
-                checked={showMinimap}
-                onCheckedChange={handleToggleMinimap}
-              >
-                Show Minimap
-                <MenubarShortcut>
-                  {getShortcutDisplay("toggle-minimap")}
-                </MenubarShortcut>
-              </MenubarCheckboxItem>
-              <MenubarSeparator />
+      <MenubarMenu>
+        <MenubarTrigger>View</MenubarTrigger>
+        <MenubarContent>
+          <MenubarItem onClick={handleZoomIn}>
+            Zoom In
+            <MenubarShortcut>{getShortcutDisplay("zoom-in")}</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem onClick={handleZoomOut}>
+            Zoom Out
+            <MenubarShortcut>{getShortcutDisplay("zoom-out")}</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem onClick={handleFitView}>
+            Fit View
+            <MenubarShortcut>{getShortcutDisplay("fit-view")}</MenubarShortcut>
+          </MenubarItem>
+          <MenubarSeparator />
+          <MenubarCheckboxItem
+            checked={showGrid}
+            onCheckedChange={handleToggleGrid}
+          >
+            Show Grid
+            <MenubarShortcut>{getShortcutDisplay("toggle-grid")}</MenubarShortcut>
+          </MenubarCheckboxItem>
+          <MenubarCheckboxItem
+            checked={showMinimap}
+            onCheckedChange={handleToggleMinimap}
+          >
+            Show Minimap
+            <MenubarShortcut>{getShortcutDisplay("toggle-minimap")}</MenubarShortcut>
+          </MenubarCheckboxItem>
+          <MenubarSeparator />
+          <MenubarSub>
+            <MenubarSubTrigger>Theme</MenubarSubTrigger>
+            <MenubarSubContent>
               <MenubarSub>
-                <MenubarSubTrigger>Theme</MenubarSubTrigger>
+                <MenubarSubTrigger>Boring</MenubarSubTrigger>
                 <MenubarSubContent>
-                  <MenubarSub>
-                    <MenubarSubTrigger>Boring</MenubarSubTrigger>
-                    <MenubarSubContent>
-                      <MenubarItem onClick={() => setTheme('light')}>
-                        Light
-                        {theme === 'light' && (
-                          <Check className="h-4 w-4 ml-auto" />
-                        )}
-                      </MenubarItem>
-                      <MenubarItem onClick={() => setTheme('dark')}>
-                        Dark
-                        {theme === 'dark' && (
-                          <Check className="h-4 w-4 ml-auto" />
-                        )}
-                      </MenubarItem>
-                    </MenubarSubContent>
-                  </MenubarSub>
-                  <MenubarSub>
-                    <MenubarSubTrigger>Less Boring</MenubarSubTrigger>
-                    <MenubarSubContent>
-                      <MenubarItem onClick={() => setTheme('tokyo-night-light')}>
-                        Light
-                        {theme === 'tokyo-night-light' && (
-                          <Check className="h-4 w-4 ml-auto" />
-                        )}
-                      </MenubarItem>
-                      <MenubarItem onClick={() => setTheme('tokyo-night-dark')}>
-                        Dark
-                        {theme === 'tokyo-night-dark' && (
-                          <Check className="h-4 w-4 ml-auto" />
-                        )}
-                      </MenubarItem>
-                    </MenubarSubContent>
-                  </MenubarSub>
+                  <MenubarItem onClick={() => setTheme('light')}>
+                    Light
+                    {theme === 'light' && <Check className="h-4 w-4 ml-auto" />}
+                  </MenubarItem>
+                  <MenubarItem onClick={() => setTheme('dark')}>
+                    Dark
+                    {theme === 'dark' && <Check className="h-4 w-4 ml-auto" />}
+                  </MenubarItem>
                 </MenubarSubContent>
               </MenubarSub>
-            </MenubarContent>
-          </MenubarMenu>
+              <MenubarSub>
+                <MenubarSubTrigger>Less Boring</MenubarSubTrigger>
+                <MenubarSubContent>
+                  <MenubarItem onClick={() => setTheme('tokyo-night-light')}>
+                    Light
+                    {theme === 'tokyo-night-light' && (
+                      <Check className="h-4 w-4 ml-auto" />
+                    )}
+                  </MenubarItem>
+                  <MenubarItem onClick={() => setTheme('tokyo-night-dark')}>
+                    Dark
+                    {theme === 'tokyo-night-dark' && (
+                      <Check className="h-4 w-4 ml-auto" />
+                    )}
+                  </MenubarItem>
+                </MenubarSubContent>
+              </MenubarSub>
+            </MenubarSubContent>
+          </MenubarSub>
+        </MenubarContent>
+      </MenubarMenu>
 
-          <MenubarMenu>
-            <MenubarTrigger>Help</MenubarTrigger>
-            <MenubarContent>
-              <MenubarItem
-                onClick={() => setHelpDialogOpen(true)}
-                data-help-dialog-trigger
-              >
-                Documentation
-                <MenubarShortcut>{getShortcutDisplay("help")}</MenubarShortcut>
-              </MenubarItem>
-              <MenubarItem
-                onClick={() => {
-                  setHelpDialogOpen(true);
-                  // Set active tab to shortcuts
-                  setTimeout(() => {
-                    const shortcutsTab = document.querySelector(
-                      '[data-tab="shortcuts"]'
-                    ) as HTMLElement;
-                    if (shortcutsTab) shortcutsTab.click();
-                  }, 100);
-                }}
-              >
-                Keyboard Shortcuts
-                <MenubarShortcut>
-                  {getShortcutDisplay("keyboard-shortcuts")}
-                </MenubarShortcut>
-              </MenubarItem>
-              <MenubarSeparator />
-              <MenubarItem onClick={() => setAboutDialogOpen(true)}>
-                About IFCflow
-              </MenubarItem>
-            </MenubarContent>
-          </MenubarMenu>
-        </Menubar>
-
-        <div className="flex items-center space-x-2">
-          <Button
-            variant={isRunning ? "destructive" : "default"}
-            size="sm"
-            className="gap-1"
-            onClick={handleRunWorkflow}
-            data-testid="run-workflow-button"
+      <MenubarMenu>
+        <MenubarTrigger>Help</MenubarTrigger>
+        <MenubarContent>
+          <MenubarItem
+            onClick={() => setHelpDialogOpen(true)}
+            data-help-dialog-trigger
           >
-            {isRunning ? (
-              <Pause className="h-4 w-4" />
-            ) : (
-              <Play className="h-4 w-4" />
-            )}
-            {isRunning ? "Stop" : "Run"}
-          </Button>
+            Documentation
+            <MenubarShortcut>{getShortcutDisplay("help")}</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem
+            onClick={() => {
+              setHelpDialogOpen(true);
+              setTimeout(() => {
+                const shortcutsTab = document.querySelector(
+                  '[data-tab="shortcuts"]'
+                ) as HTMLElement;
+                if (shortcutsTab) shortcutsTab.click();
+              }, 100);
+            }}
+          >
+            Keyboard Shortcuts
+            <MenubarShortcut>
+              {getShortcutDisplay("keyboard-shortcuts")}
+            </MenubarShortcut>
+          </MenubarItem>
+          <MenubarSeparator />
+          <MenubarItem onClick={() => setAboutDialogOpen(true)}>
+            About IFCflow
+          </MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+    </Menubar>
+  );
 
+  const RunSection = () => (
+    <div className="flex items-center space-x-2">
+      <Button
+        variant={isRunning ? "destructive" : "default"}
+        size="sm"
+        className="gap-1"
+        onClick={handleRunWorkflow}
+        data-testid="run-workflow-button"
+      >
+        {isRunning ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+        {isRunning ? "Stop" : "Run"}
+      </Button>
+
+      {currentWorkflow && (
+        <div className="text-sm font-medium mr-2">{currentWorkflow.name}</div>
+      )}
+    </div>
+  );
+
+  return (
+    <>
+      {/* Desktop menu */}
+      <div className="hidden md:flex items-center justify-between border-b p-1 bg-card">
+        <MenuContent />
+        <RunSection />
+      </div>
+
+      {/* Mobile header */}
+      <div className="flex md:hidden items-center justify-between border-b p-2 bg-card">
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="icon" onClick={onToggleSidebar}>
+            <Menu className="h-5 w-5" />
+            <span className="sr-only">Toggle sidebar</span>
+          </Button>
           {currentWorkflow && (
-            <div className="text-sm font-medium mr-2">
-              {currentWorkflow.name}
-            </div>
+            <span className="text-sm font-medium">{currentWorkflow.name}</span>
           )}
         </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant={isRunning ? "destructive" : "default"}
+            size="icon"
+            onClick={handleRunWorkflow}
+          >
+            {isRunning ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+            <span className="sr-only">Run</span>
+          </Button>
+          <Button variant="ghost" size="icon" onClick={() => setMobileMenuOpen(true)}>
+            <MoreVertical className="h-5 w-5" />
+            <span className="sr-only">Open menu</span>
+          </Button>
+        </div>
       </div>
+
+      {/* Mobile menu sheet */}
+      <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
+        <SheetContent side="top" className="p-2 pt-4">
+          <MenuContent />
+          <div className="mt-4">
+            <RunSection />
+          </div>
+        </SheetContent>
+      </Sheet>
 
       <OpenFileDialog
         open={openFileDialogOpen}

--- a/pages/_document.cjs
+++ b/pages/_document.cjs
@@ -3,11 +3,13 @@ import { Html, Head, Main, NextScript } from 'next/document'
 export default function Document() {
     return (
         <Html lang="en">
-            <Head />
+            <Head>
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+            </Head>
             <body>
                 <Main />
                 <NextScript />
             </body>
         </Html>
     )
-} 
+}


### PR DESCRIPTION
## Summary
- add viewport meta tag
- implement responsive menubar with mobile header and menu drawer
- adapt home page to show sidebar in a sheet on mobile

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_687cb2ddd87c832084d4a0de58092836