### PR TITLE
Fix mobile menu dialogs

### DIFF
--- a/components/menubar.tsx
+++ b/components/menubar.tsx
@@ -99,6 +99,10 @@ export function AppMenubar({
   const { shortcuts } = useKeyboardShortcuts();
   const { theme, setTheme } = useTheme();
 
+  const closeMobileMenu = () => {
+    if (isMobile) setMobileMenuOpen(false);
+  };
+
   // Find shortcut by ID
   const findShortcut = (id: string) => {
     return shortcuts.find((s) => s.id === id);
@@ -264,21 +268,30 @@ export function AppMenubar({
         <MenubarTrigger>File</MenubarTrigger>
         <MenubarContent>
           <MenubarItem
-            onClick={() => setOpenFileDialogOpen(true)}
+            onClick={() => {
+              closeMobileMenu();
+              setOpenFileDialogOpen(true);
+            }}
             data-open-file-dialog-trigger
           >
             Open IFC File
             <MenubarShortcut>{getShortcutDisplay("open-file")}</MenubarShortcut>
           </MenubarItem>
           <MenubarItem
-            onClick={() => setSaveWorkflowDialogOpen(true)}
+            onClick={() => {
+              closeMobileMenu();
+              setSaveWorkflowDialogOpen(true);
+            }}
             data-save-workflow-dialog-trigger
           >
             Save Workflow
             <MenubarShortcut>{getShortcutDisplay("save-workflow")}</MenubarShortcut>
           </MenubarItem>
           <MenubarItem
-            onClick={() => setWorkflowLibraryOpen(true)}
+            onClick={() => {
+              closeMobileMenu();
+              setWorkflowLibraryOpen(true);
+            }}
             data-workflow-library-trigger
           >
             Open Workflow Library
@@ -290,33 +303,70 @@ export function AppMenubar({
       <MenubarMenu>
         <MenubarTrigger>Edit</MenubarTrigger>
         <MenubarContent>
-          <MenubarItem onClick={handleUndo} disabled={!canUndo}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu();
+              handleUndo();
+            }}
+            disabled={!canUndo}
+          >
             Undo
             <MenubarShortcut>{getShortcutDisplay("undo")}</MenubarShortcut>
           </MenubarItem>
-          <MenubarItem onClick={handleRedo} disabled={!canRedo}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu();
+              handleRedo();
+            }}
+            disabled={!canRedo}
+          >
             Redo
             <MenubarShortcut>{getShortcutDisplay("redo")}</MenubarShortcut>
           </MenubarItem>
           <MenubarSeparator />
-          <MenubarItem onClick={onCut}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu();
+              onCut();
+            }}
+          >
             Cut
             <MenubarShortcut>{getShortcutDisplay("cut")}</MenubarShortcut>
           </MenubarItem>
-          <MenubarItem onClick={onCopy}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu();
+              onCopy();
+            }}
+          >
             Copy
             <MenubarShortcut>{getShortcutDisplay("copy")}</MenubarShortcut>
           </MenubarItem>
-          <MenubarItem onClick={onPaste}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu();
+              onPaste();
+            }}
+          >
             Paste
             <MenubarShortcut>{getShortcutDisplay("paste")}</MenubarShortcut>
           </MenubarItem>
           <MenubarSeparator />
-          <MenubarItem onClick={onSelectAll}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu();
+              onSelectAll();
+            }}
+          >
             Select All
             <MenubarShortcut>{getShortcutDisplay("select-all")}</MenubarShortcut>
           </MenubarItem>
-          <MenubarItem onClick={onDelete}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu();
+              onDelete();
+            }}
+          >
             Delete Selected
             <MenubarShortcut>{getShortcutDisplay("delete")}</MenubarShortcut>
           </MenubarItem>
@@ -326,29 +376,50 @@ export function AppMenubar({
       <MenubarMenu>
         <MenubarTrigger>View</MenubarTrigger>
         <MenubarContent>
-          <MenubarItem onClick={handleZoomIn}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu();
+              handleZoomIn();
+            }}
+          >
             Zoom In
             <MenubarShortcut>{getShortcutDisplay("zoom-in")}</MenubarShortcut>
           </MenubarItem>
-          <MenubarItem onClick={handleZoomOut}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu();
+              handleZoomOut();
+            }}
+          >
             Zoom Out
             <MenubarShortcut>{getShortcutDisplay("zoom-out")}</MenubarShortcut>
           </MenubarItem>
-          <MenubarItem onClick={handleFitView}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu();
+              handleFitView();
+            }}
+          >
             Fit View
             <MenubarShortcut>{getShortcutDisplay("fit-view")}</MenubarShortcut>
           </MenubarItem>
           <MenubarSeparator />
           <MenubarCheckboxItem
             checked={showGrid}
-            onCheckedChange={handleToggleGrid}
+            onCheckedChange={() => {
+              closeMobileMenu();
+              handleToggleGrid();
+            }}
           >
             Show Grid
             <MenubarShortcut>{getShortcutDisplay("toggle-grid")}</MenubarShortcut>
           </MenubarCheckboxItem>
           <MenubarCheckboxItem
             checked={showMinimap}
-            onCheckedChange={handleToggleMinimap}
+            onCheckedChange={() => {
+              closeMobileMenu();
+              handleToggleMinimap();
+            }}
           >
             Show Minimap
             <MenubarShortcut>{getShortcutDisplay("toggle-minimap")}</MenubarShortcut>
@@ -360,11 +431,21 @@ export function AppMenubar({
               <MenubarSub>
                 <MenubarSubTrigger>Boring</MenubarSubTrigger>
                 <MenubarSubContent>
-                  <MenubarItem onClick={() => setTheme('light')}>
+                  <MenubarItem
+                    onClick={() => {
+                      closeMobileMenu();
+                      setTheme('light');
+                    }}
+                  >
                     Light
                     {theme === 'light' && <Check className="h-4 w-4 ml-auto" />}
                   </MenubarItem>
-                  <MenubarItem onClick={() => setTheme('dark')}>
+                  <MenubarItem
+                    onClick={() => {
+                      closeMobileMenu();
+                      setTheme('dark');
+                    }}
+                  >
                     Dark
                     {theme === 'dark' && <Check className="h-4 w-4 ml-auto" />}
                   </MenubarItem>
@@ -373,13 +454,23 @@ export function AppMenubar({
               <MenubarSub>
                 <MenubarSubTrigger>Less Boring</MenubarSubTrigger>
                 <MenubarSubContent>
-                  <MenubarItem onClick={() => setTheme('tokyo-night-light')}>
+                  <MenubarItem
+                    onClick={() => {
+                      closeMobileMenu();
+                      setTheme('tokyo-night-light');
+                    }}
+                  >
                     Light
                     {theme === 'tokyo-night-light' && (
                       <Check className="h-4 w-4 ml-auto" />
                     )}
                   </MenubarItem>
-                  <MenubarItem onClick={() => setTheme('tokyo-night-dark')}>
+                  <MenubarItem
+                    onClick={() => {
+                      closeMobileMenu();
+                      setTheme('tokyo-night-dark');
+                    }}
+                  >
                     Dark
                     {theme === 'tokyo-night-dark' && (
                       <Check className="h-4 w-4 ml-auto" />
@@ -396,7 +487,10 @@ export function AppMenubar({
         <MenubarTrigger>Help</MenubarTrigger>
         <MenubarContent>
           <MenubarItem
-            onClick={() => setHelpDialogOpen(true)}
+            onClick={() => {
+              closeMobileMenu();
+              setHelpDialogOpen(true);
+            }}
             data-help-dialog-trigger
           >
             Documentation
@@ -404,6 +498,7 @@ export function AppMenubar({
           </MenubarItem>
           <MenubarItem
             onClick={() => {
+              closeMobileMenu();
               setHelpDialogOpen(true);
               setTimeout(() => {
                 const shortcutsTab = document.querySelector(
@@ -419,7 +514,11 @@ export function AppMenubar({
             </MenubarShortcut>
           </MenubarItem>
           <MenubarSeparator />
-          <MenubarItem onClick={() => setAboutDialogOpen(true)}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu();
+              setAboutDialogOpen(true);
+            }}>
             About IFCflow
           </MenubarItem>
         </MenubarContent>


### PR DESCRIPTION
## Summary
- close the mobile menu when triggering menu actions
- ensure About dialog is closable on mobile

## Testing
- `npm run lint` *(fails: prompts for setup)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_687d14b582d88320ad0d7517cc48fdad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile menus now automatically close when a menu action is triggered, improving navigation on mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->