### PR TITLE
Fix mobile menu item behaviour

### DIFF
--- a/components/menubar.tsx
+++ b/components/menubar.tsx
@@ -95,6 +95,9 @@ export function AppMenubar({
   const [aboutDialogOpen, setAboutDialogOpen] = useState(false);
   const isMobile = useIsMobile();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const closeMobileMenu = () => {
+    if (isMobile) setMobileMenuOpen(false)
+  }
   const { toast } = useToast();
   const { shortcuts } = useKeyboardShortcuts();
   const { theme, setTheme } = useTheme();
@@ -264,21 +267,30 @@ export function AppMenubar({
         <MenubarTrigger>File</MenubarTrigger>
         <MenubarContent>
           <MenubarItem
-            onClick={() => setOpenFileDialogOpen(true)}
+            onClick={() => {
+              closeMobileMenu()
+              setOpenFileDialogOpen(true)
+            }}
             data-open-file-dialog-trigger
           >
             Open IFC File
             <MenubarShortcut>{getShortcutDisplay("open-file")}</MenubarShortcut>
           </MenubarItem>
           <MenubarItem
-            onClick={() => setSaveWorkflowDialogOpen(true)}
+            onClick={() => {
+              closeMobileMenu()
+              setSaveWorkflowDialogOpen(true)
+            }}
             data-save-workflow-dialog-trigger
           >
             Save Workflow
             <MenubarShortcut>{getShortcutDisplay("save-workflow")}</MenubarShortcut>
           </MenubarItem>
           <MenubarItem
-            onClick={() => setWorkflowLibraryOpen(true)}
+            onClick={() => {
+              closeMobileMenu()
+              setWorkflowLibraryOpen(true)
+            }}
             data-workflow-library-trigger
           >
             Open Workflow Library
@@ -290,33 +302,70 @@ export function AppMenubar({
       <MenubarMenu>
         <MenubarTrigger>Edit</MenubarTrigger>
         <MenubarContent>
-          <MenubarItem onClick={handleUndo} disabled={!canUndo}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu()
+              handleUndo()
+            }}
+            disabled={!canUndo}
+          >
             Undo
             <MenubarShortcut>{getShortcutDisplay("undo")}</MenubarShortcut>
           </MenubarItem>
-          <MenubarItem onClick={handleRedo} disabled={!canRedo}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu()
+              handleRedo()
+            }}
+            disabled={!canRedo}
+          >
             Redo
             <MenubarShortcut>{getShortcutDisplay("redo")}</MenubarShortcut>
           </MenubarItem>
           <MenubarSeparator />
-          <MenubarItem onClick={onCut}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu()
+              onCut()
+            }}
+          >
             Cut
             <MenubarShortcut>{getShortcutDisplay("cut")}</MenubarShortcut>
           </MenubarItem>
-          <MenubarItem onClick={onCopy}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu()
+              onCopy()
+            }}
+          >
             Copy
             <MenubarShortcut>{getShortcutDisplay("copy")}</MenubarShortcut>
           </MenubarItem>
-          <MenubarItem onClick={onPaste}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu()
+              onPaste()
+            }}
+          >
             Paste
             <MenubarShortcut>{getShortcutDisplay("paste")}</MenubarShortcut>
           </MenubarItem>
           <MenubarSeparator />
-          <MenubarItem onClick={onSelectAll}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu()
+              onSelectAll()
+            }}
+          >
             Select All
             <MenubarShortcut>{getShortcutDisplay("select-all")}</MenubarShortcut>
           </MenubarItem>
-          <MenubarItem onClick={onDelete}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu()
+              onDelete()
+            }}
+          >
             Delete Selected
             <MenubarShortcut>{getShortcutDisplay("delete")}</MenubarShortcut>
           </MenubarItem>
@@ -326,29 +375,47 @@ export function AppMenubar({
       <MenubarMenu>
         <MenubarTrigger>View</MenubarTrigger>
         <MenubarContent>
-          <MenubarItem onClick={handleZoomIn}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu()
+              handleZoomIn()
+            }}>
             Zoom In
             <MenubarShortcut>{getShortcutDisplay("zoom-in")}</MenubarShortcut>
           </MenubarItem>
-          <MenubarItem onClick={handleZoomOut}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu()
+              handleZoomOut()
+            }}>
             Zoom Out
             <MenubarShortcut>{getShortcutDisplay("zoom-out")}</MenubarShortcut>
           </MenubarItem>
-          <MenubarItem onClick={handleFitView}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu()
+              handleFitView()
+            }}>
             Fit View
             <MenubarShortcut>{getShortcutDisplay("fit-view")}</MenubarShortcut>
           </MenubarItem>
           <MenubarSeparator />
           <MenubarCheckboxItem
             checked={showGrid}
-            onCheckedChange={handleToggleGrid}
+            onCheckedChange={() => {
+              closeMobileMenu()
+              handleToggleGrid()
+            }}
           >
             Show Grid
             <MenubarShortcut>{getShortcutDisplay("toggle-grid")}</MenubarShortcut>
           </MenubarCheckboxItem>
           <MenubarCheckboxItem
             checked={showMinimap}
-            onCheckedChange={handleToggleMinimap}
+            onCheckedChange={() => {
+              closeMobileMenu()
+              handleToggleMinimap()
+            }}
           >
             Show Minimap
             <MenubarShortcut>{getShortcutDisplay("toggle-minimap")}</MenubarShortcut>
@@ -360,11 +427,19 @@ export function AppMenubar({
               <MenubarSub>
                 <MenubarSubTrigger>Boring</MenubarSubTrigger>
                 <MenubarSubContent>
-                  <MenubarItem onClick={() => setTheme('light')}>
+                  <MenubarItem
+                    onClick={() => {
+                      closeMobileMenu()
+                      setTheme('light')
+                    }}>
                     Light
                     {theme === 'light' && <Check className="h-4 w-4 ml-auto" />}
                   </MenubarItem>
-                  <MenubarItem onClick={() => setTheme('dark')}>
+                  <MenubarItem
+                    onClick={() => {
+                      closeMobileMenu()
+                      setTheme('dark')
+                    }}>
                     Dark
                     {theme === 'dark' && <Check className="h-4 w-4 ml-auto" />}
                   </MenubarItem>
@@ -373,13 +448,21 @@ export function AppMenubar({
               <MenubarSub>
                 <MenubarSubTrigger>Less Boring</MenubarSubTrigger>
                 <MenubarSubContent>
-                  <MenubarItem onClick={() => setTheme('tokyo-night-light')}>
+                  <MenubarItem
+                    onClick={() => {
+                      closeMobileMenu()
+                      setTheme('tokyo-night-light')
+                    }}>
                     Light
                     {theme === 'tokyo-night-light' && (
                       <Check className="h-4 w-4 ml-auto" />
                     )}
                   </MenubarItem>
-                  <MenubarItem onClick={() => setTheme('tokyo-night-dark')}>
+                  <MenubarItem
+                    onClick={() => {
+                      closeMobileMenu()
+                      setTheme('tokyo-night-dark')
+                    }}>
                     Dark
                     {theme === 'tokyo-night-dark' && (
                       <Check className="h-4 w-4 ml-auto" />
@@ -396,7 +479,10 @@ export function AppMenubar({
         <MenubarTrigger>Help</MenubarTrigger>
         <MenubarContent>
           <MenubarItem
-            onClick={() => setHelpDialogOpen(true)}
+            onClick={() => {
+              closeMobileMenu()
+              setHelpDialogOpen(true)
+            }}
             data-help-dialog-trigger
           >
             Documentation
@@ -404,13 +490,14 @@ export function AppMenubar({
           </MenubarItem>
           <MenubarItem
             onClick={() => {
-              setHelpDialogOpen(true);
+              closeMobileMenu()
+              setHelpDialogOpen(true)
               setTimeout(() => {
                 const shortcutsTab = document.querySelector(
                   '[data-tab="shortcuts"]'
-                ) as HTMLElement;
-                if (shortcutsTab) shortcutsTab.click();
-              }, 100);
+                ) as HTMLElement
+                if (shortcutsTab) shortcutsTab.click()
+              }, 100)
             }}
           >
             Keyboard Shortcuts
@@ -419,7 +506,11 @@ export function AppMenubar({
             </MenubarShortcut>
           </MenubarItem>
           <MenubarSeparator />
-          <MenubarItem onClick={() => setAboutDialogOpen(true)}>
+          <MenubarItem
+            onClick={() => {
+              closeMobileMenu()
+              setAboutDialogOpen(true)
+            }}>
             About IFCflow
           </MenubarItem>
         </MenubarContent>


### PR DESCRIPTION
## Summary
- close the mobile menu when selecting items
- ensure help/about and other menu items dismiss the menu on mobile devices

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_687d14b582d88320ad0d7517cc48fdad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The mobile menu now automatically closes when a menu item is selected on mobile devices, providing a smoother navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->