### PR TITLE
Fix mobile dialogs overflow

### DIFF
--- a/components/dialogs/about-dialog.tsx
+++ b/components/dialogs/about-dialog.tsx
@@ -27,7 +27,7 @@ interface AboutDialogProps {
 export function AboutDialog({ open, onOpenChange }: AboutDialogProps) {
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="sm:max-w-2xl bg-background">
+            <DialogContent className="sm:max-w-2xl max-h-[90vh] overflow-y-auto bg-background">
                 <DialogHeader className="pb-2 border-b">
                     <DialogTitle className="flex items-center gap-2 text-xl">
                         <Info className="h-5 w-5 text-primary" />

--- a/components/dialogs/export-dialog.tsx
+++ b/components/dialogs/export-dialog.tsx
@@ -33,7 +33,7 @@ export function ExportDialog({ open, onOpenChange, onExport }: ExportDialogProps
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent className="sm:max-w-[425px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Export Results</DialogTitle>
           <DialogDescription>Export your workflow results to a file.</DialogDescription>

--- a/components/dialogs/open-file-dialog.tsx
+++ b/components/dialogs/open-file-dialog.tsx
@@ -51,7 +51,7 @@ export function OpenFileDialog({ open, onOpenChange, onFileSelected }: OpenFileD
         if (!isOpen) handleReset()
       }}
     >
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent className="sm:max-w-[425px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Open IFC File</DialogTitle>
           <DialogDescription>Select an IFC file to open in the viewer.</DialogDescription>

--- a/components/dialogs/save-workflow-dialog.tsx
+++ b/components/dialogs/save-workflow-dialog.tsx
@@ -199,7 +199,7 @@ export function SaveWorkflowDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-[550px]">
+      <DialogContent className="sm:max-w-[550px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Save Workflow</DialogTitle>
           <DialogDescription>

--- a/components/dialogs/settings-dialog.tsx
+++ b/components/dialogs/settings-dialog.tsx
@@ -23,7 +23,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[500px]">
+      <DialogContent className="sm:max-w-[500px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Settings</DialogTitle>
           <DialogDescription>Configure application settings and preferences.</DialogDescription>


### PR DESCRIPTION
## Summary
- limit dialog height so the close button is always visible on small screens

## Testing
- `npm run lint` *(fails: interactive question about eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_687d1887bbfc8320a61b7fda65f6d22f