### PR TITLE
Enable lasso multi-select on canvas with themed styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -317,4 +317,11 @@ body {
   .react-flow:focus-visible {
     outline: none !important;
   }
+
+  /* Lasso multi-select styling */
+  .react-flow__selection {
+    border: 1px dashed hsl(var(--primary));
+    background-color: hsl(var(--primary) / 0.08);
+    border-radius: 4px;
+  }
 }

--- a/components/flow-canvas.tsx
+++ b/components/flow-canvas.tsx
@@ -299,6 +299,8 @@ export function FlowCanvas({
         snapGrid={[15, 15]}
         minZoom={0.1}
         maxZoom={2}
+        panOnDrag={[1, 2]}
+        selectionOnDrag
       >
         <Controls />
         {showGrid && <Background color="#aaa" gap={16} />}


### PR DESCRIPTION
## Summary
- allow dragging on the canvas to draw a lasso and select multiple nodes
- style the selection rectangle with theme-aware dashed lines

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689d0222c4b08320b39f62a0cb63d0c5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Drag to pan the canvas for smoother navigation.
  - Drag to multi-select items with a selection box, improving batch operations.

- Style
  - Enhanced selection box visuals: dashed outline in the primary color, subtle semi-transparent fill, and rounded corners for clearer feedback during selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->