### PR TITLE
feat: add node grouping

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -346,6 +346,16 @@ function FlowWithProvider() {
     { enableOnFormTags: false }
   );
 
+  // Group selected nodes (Ctrl+Shift+G)
+  useHotkeys(
+    findShortcut("group") || "ctrl+shift+g,cmd+shift+g",
+    (e) => {
+      e.preventDefault();
+      handleGroup();
+    },
+    { enableOnFormTags: false }
+  );
+
   // Delete (Delete key)
   useHotkeys(
     "delete,backspace",
@@ -453,15 +463,21 @@ function FlowWithProvider() {
     // Save current state to history before deletion
     saveToHistory(nodes, edges);
 
-    const selectedNodeIds = selectedNodes.map((node) => node.id);
+    const idsToDelete = new Set<string>();
+    selectedNodes.forEach((node) => {
+      idsToDelete.add(node.id);
+      if (node.type === "groupNode") {
+        nodes.forEach((n) => {
+          if (n.parentNode === node.id) {
+            idsToDelete.add(n.id);
+          }
+        });
+      }
+    });
 
-    // Remove selected nodes
-    const remainingNodes = nodes.filter((node) => !node.selected);
-    // Remove edges connected to deleted nodes
+    const remainingNodes = nodes.filter((node) => !idsToDelete.has(node.id));
     const remainingEdges = edges.filter(
-      (edge) =>
-        !selectedNodeIds.includes(edge.source) &&
-        !selectedNodeIds.includes(edge.target)
+      (edge) => !idsToDelete.has(edge.source) && !idsToDelete.has(edge.target)
     );
 
     setNodes(remainingNodes);
@@ -469,7 +485,7 @@ function FlowWithProvider() {
 
     toast({
       title: "Deleted",
-      description: `${selectedNodes.length} node(s) deleted`,
+      description: `${idsToDelete.size} node(s) deleted`,
     });
   }, [nodes, edges, saveToHistory, setNodes, setEdges, toast]);
 
@@ -529,6 +545,63 @@ function FlowWithProvider() {
       description: `${newNodes.length} node(s) and ${newEdges.length} connection(s) pasted`,
     });
   }, [clipboard, nodes, edges, saveToHistory, setNodes, setEdges, toast]);
+
+  // Handle grouping selected nodes
+  const handleGroup = useCallback(() => {
+    const selectedNodes = nodes.filter(
+      (n) => n.selected && n.type !== "groupNode"
+    );
+    if (selectedNodes.length === 0) return;
+
+    saveToHistory(nodes, edges);
+
+    const padding = 40;
+    const minX = Math.min(...selectedNodes.map((n) => n.position.x));
+    const minY = Math.min(...selectedNodes.map((n) => n.position.y));
+    const maxX = Math.max(
+      ...selectedNodes.map((n) => n.position.x + (n.width || 0))
+    );
+    const maxY = Math.max(
+      ...selectedNodes.map((n) => n.position.y + (n.height || 0))
+    );
+
+    const groupId = `group-${Date.now()}`;
+    const position = { x: minX - padding, y: minY - padding };
+    const width = maxX - minX + padding * 2;
+    const height = maxY - minY + padding * 2;
+
+    const groupNode: Node = {
+      id: groupId,
+      type: "groupNode",
+      position,
+      data: { label: "Group", backgroundColor: "rgba(0,0,0,0.05)" },
+      style: { width, height },
+      selected: true,
+    };
+
+    const updatedNodes = nodes.map((n) => {
+      if (selectedNodes.some((sn) => sn.id === n.id)) {
+        return {
+          ...n,
+          parentNode: groupId,
+          position: {
+            x: n.position.x - position.x,
+            y: n.position.y - position.y,
+          },
+          extent: "parent",
+          selected: false,
+        };
+      }
+      return n;
+    });
+
+    setNodes([...updatedNodes, groupNode]);
+
+    toast({
+      title: "Group Created",
+      description: `${selectedNodes.length} node(s) grouped`,
+    });
+  }, [nodes, edges, saveToHistory, setNodes, toast]);
 
   // Updated node changes handler with history
   const handleNodesChange = useCallback(
@@ -1093,6 +1166,12 @@ function FlowWithProvider() {
             event.preventDefault();
             handleSelectAll();
             break;
+          case 'g':
+            if (event.shiftKey) {
+              event.preventDefault();
+              handleGroup();
+            }
+            break;
         }
       }
 
@@ -1110,7 +1189,7 @@ function FlowWithProvider() {
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [nodes, handleCopy, handlePaste, handleSelectAll, handleDelete]);
+  }, [nodes, handleCopy, handlePaste, handleSelectAll, handleDelete, handleGroup]);
 
   return (
     <div className="flex h-screen w-full bg-background">
@@ -1183,6 +1262,7 @@ function FlowWithProvider() {
           onCut={handleCut}
           onPaste={handlePaste}
           onDelete={handleDelete}
+          onGroup={handleGroup}
           onToggleSidebar={handleSidebarToggle}
           sidebarOpen={sidebarOpen}
         />

--- a/components/menubar.tsx
+++ b/components/menubar.tsx
@@ -58,6 +58,7 @@ interface AppMenubarProps {
   onCut: () => void;
   onPaste: () => void;
   onDelete: () => void;
+  onGroup: () => void;
   onToggleSidebar: () => void;
   sidebarOpen?: boolean;
 }
@@ -85,6 +86,7 @@ export function AppMenubar({
   onCut,
   onPaste,
   onDelete,
+  onGroup,
   onToggleSidebar,
   sidebarOpen = false,
 }: AppMenubarProps) {
@@ -311,6 +313,10 @@ export function AppMenubar({
           <MenubarItem onClick={onPaste}>
             Paste
             <MenubarShortcut>{getShortcutDisplay("paste")}</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem onClick={onGroup}>
+            Group Selected
+            <MenubarShortcut>{getShortcutDisplay("group")}</MenubarShortcut>
           </MenubarItem>
           <MenubarSeparator />
           <MenubarItem onClick={onSelectAll}>

--- a/components/nodes/group-node.tsx
+++ b/components/nodes/group-node.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { memo, useState } from "react";
+import { useReactFlow, type NodeProps } from "reactflow";
+
+interface GroupNodeData {
+  label?: string;
+  backgroundColor?: string;
+}
+
+export const GroupNode = memo(({ id, data }: NodeProps<GroupNodeData>) => {
+  const { setNodes } = useReactFlow();
+  const [editing, setEditing] = useState(false);
+  const label = data?.label ?? "Group";
+  const bg = data?.backgroundColor || "rgba(0,0,0,0.05)";
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setNodes((nds) =>
+      nds.map((n) =>
+        n.id === id ? { ...n, data: { ...n.data, label: value } } : n
+      )
+    );
+  };
+
+  return (
+    <div
+      className="w-full h-full border border-muted-foreground rounded bg-opacity-50 relative"
+      style={{ backgroundColor: bg }}
+    >
+      <div className="absolute top-1 left-1 text-xs font-medium text-foreground">
+        {editing ? (
+          <input
+            className="bg-transparent border border-input rounded px-1 py-0.5 text-xs outline-none"
+            autoFocus
+            value={label}
+            onChange={handleChange}
+            onBlur={() => setEditing(false)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                (e.target as HTMLInputElement).blur();
+              }
+            }}
+          />
+        ) : (
+          <span onDoubleClick={() => setEditing(true)}>{label}</span>
+        )}
+      </div>
+    </div>
+  );
+});
+
+GroupNode.displayName = "GroupNode";
+
+export type { GroupNodeData };
+

--- a/components/nodes/index.ts
+++ b/components/nodes/index.ts
@@ -16,6 +16,7 @@ import { ParameterNode } from "./parameter-node"
 import { PythonNode } from "./python-node"
 import { DataTransformNode } from "./data-transform-node"
 import { ClusterNode } from "./cluster-node"
+import { GroupNode } from "./group-node"
 
 // Define custom node types as a constant to prevent React Flow warning
 export const nodeTypes: NodeTypes = {
@@ -36,6 +37,7 @@ export const nodeTypes: NodeTypes = {
   pythonNode: PythonNode,
   dataTransformNode: DataTransformNode,
   clusterNode: ClusterNode,
+  groupNode: GroupNode,
 } as const
 
 export {
@@ -56,5 +58,6 @@ export {
   ParameterNode,
   PythonNode,
   ClusterNode,
+  GroupNode,
 }
 

--- a/components/nodes/node-types.ts
+++ b/components/nodes/node-types.ts
@@ -185,4 +185,9 @@ export interface WatchNodeData extends BaseNodeData {
         watchType?: string;
         [key: string]: any;
     };
-} 
+}
+
+// Group node data
+export interface GroupNodeData extends BaseNodeData {
+    backgroundColor?: string;
+}

--- a/lib/keyboard-shortcuts.ts
+++ b/lib/keyboard-shortcuts.ts
@@ -123,6 +123,14 @@ export function getDefaultShortcuts(): KeyboardShortcut[] {
       action: () => {},
     },
     {
+      id: "group",
+      name: "Group Selected",
+      description: "Group selected nodes",
+      keys: `${mod}+shift+g`,
+      category: "edit",
+      action: () => {},
+    },
+    {
       id: "delete",
       name: "Delete",
       description: "Delete selected nodes",


### PR DESCRIPTION
## Summary
- add lightweight group node component
- allow grouping selected nodes via menu or Ctrl+Shift+G
- wire grouping into keyboard shortcuts and delete handler

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689d02ec41148320ac9dcd959734d891