### PR TITLE
feat: add node grouping capability

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -346,6 +346,21 @@ function FlowWithProvider() {
     { enableOnFormTags: false }
   );
 
+  // Group (Ctrl+G)
+  useHotkeys(
+    findShortcut("group") || "ctrl+g,cmd+g",
+    (e) => {
+      const selectedNodes = nodes.filter(
+        (node) => node.selected && node.type !== "groupNode"
+      );
+      if (selectedNodes.length > 0) {
+        e.preventDefault();
+        handleGroup();
+      }
+    },
+    { enableOnFormTags: false }
+  );
+
   // Delete (Delete key)
   useHotkeys(
     "delete,backspace",
@@ -529,6 +544,63 @@ function FlowWithProvider() {
       description: `${newNodes.length} node(s) and ${newEdges.length} connection(s) pasted`,
     });
   }, [clipboard, nodes, edges, saveToHistory, setNodes, setEdges, toast]);
+
+  // Handle grouping of selected nodes
+  const handleGroup = useCallback(() => {
+    const selectedNodes = nodes.filter(
+      (node) => node.selected && node.type !== "groupNode"
+    );
+    if (selectedNodes.length === 0) return;
+
+    saveToHistory(nodes, edges);
+
+    const padding = 40;
+    const minX = Math.min(...selectedNodes.map((n) => n.position.x));
+    const minY = Math.min(...selectedNodes.map((n) => n.position.y));
+    const maxX = Math.max(
+      ...selectedNodes.map((n) => n.position.x + (n.width || 0))
+    );
+    const maxY = Math.max(
+      ...selectedNodes.map((n) => n.position.y + (n.height || 0))
+    );
+
+    const groupId = `group-${Date.now()}`;
+    const groupPosition = { x: minX - padding / 2, y: minY - padding / 2 };
+    const groupWidth = maxX - minX + padding;
+    const groupHeight = maxY - minY + padding;
+
+    const updatedNodes = nodes.map((node) => {
+      if (selectedNodes.some((sn) => sn.id === node.id)) {
+        return {
+          ...node,
+          selected: false,
+          position: {
+            x: node.position.x - groupPosition.x,
+            y: node.position.y - groupPosition.y,
+          },
+          parentNode: groupId,
+          extent: "parent",
+        };
+      }
+      return node;
+    });
+
+    const groupNode: Node = {
+      id: groupId,
+      type: "groupNode",
+      position: groupPosition,
+      data: { label: "Group", backgroundColor: "rgba(0,0,0,0.03)" },
+      style: { width: groupWidth, height: groupHeight },
+      selected: true,
+    };
+
+    setNodes([groupNode, ...updatedNodes]);
+
+    toast({
+      title: "Group created",
+      description: `${selectedNodes.length} node(s) grouped`,
+    });
+  }, [nodes, edges, saveToHistory, setNodes, toast]);
 
   // Updated node changes handler with history
   const handleNodesChange = useCallback(
@@ -1182,6 +1254,7 @@ function FlowWithProvider() {
           onCopy={handleCopy}
           onCut={handleCut}
           onPaste={handlePaste}
+          onGroup={handleGroup}
           onDelete={handleDelete}
           onToggleSidebar={handleSidebarToggle}
           sidebarOpen={sidebarOpen}

--- a/components/menubar.tsx
+++ b/components/menubar.tsx
@@ -58,6 +58,7 @@ interface AppMenubarProps {
   onCut: () => void;
   onPaste: () => void;
   onDelete: () => void;
+  onGroup: () => void;
   onToggleSidebar: () => void;
   sidebarOpen?: boolean;
 }
@@ -85,6 +86,7 @@ export function AppMenubar({
   onCut,
   onPaste,
   onDelete,
+  onGroup,
   onToggleSidebar,
   sidebarOpen = false,
 }: AppMenubarProps) {
@@ -311,6 +313,13 @@ export function AppMenubar({
           <MenubarItem onClick={onPaste}>
             Paste
             <MenubarShortcut>{getShortcutDisplay("paste")}</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem
+            onClick={onGroup}
+            disabled={!(reactFlowInstance && reactFlowInstance.getNodes().some((n) => n.selected))}
+          >
+            Group
+            <MenubarShortcut>{getShortcutDisplay("group")}</MenubarShortcut>
           </MenubarItem>
           <MenubarSeparator />
           <MenubarItem onClick={onSelectAll}>

--- a/components/nodes/group-node.tsx
+++ b/components/nodes/group-node.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+import { NodeProps, useReactFlow } from "reactflow";
+import { cn } from "@/lib/utils";
+import type { GroupNodeData } from "./node-types";
+
+export function GroupNode({ id, data, selected }: NodeProps<GroupNodeData>) {
+  const { setNodes } = useReactFlow();
+  const [editing, setEditing] = useState(false);
+  const [label, setLabel] = useState(data.label);
+
+  const handleBlur = () => {
+    setNodes((nds) =>
+      nds.map((node) =>
+        node.id === id ? { ...node, data: { ...node.data, label } } : node
+      )
+    );
+    setEditing(false);
+  };
+
+  return (
+    <div
+      className={cn(
+        "relative w-full h-full rounded-md border-2",
+        selected ? "border-blue-500" : "border-gray-400",
+      )}
+      style={{ backgroundColor: data.backgroundColor || "rgba(0,0,0,0.03)" }}
+    >
+      <div className="absolute top-1 left-1 text-xs">
+        {editing ? (
+          <input
+            className="bg-transparent outline-none border-none"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            onBlur={handleBlur}
+            onKeyDown={(e) => e.key === "Enter" && handleBlur()}
+            autoFocus
+          />
+        ) : (
+          <span onDoubleClick={() => setEditing(true)}>{data.label}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/nodes/index.ts
+++ b/components/nodes/index.ts
@@ -16,6 +16,7 @@ import { ParameterNode } from "./parameter-node"
 import { PythonNode } from "./python-node"
 import { DataTransformNode } from "./data-transform-node"
 import { ClusterNode } from "./cluster-node"
+import { GroupNode } from "./group-node"
 
 // Define custom node types as a constant to prevent React Flow warning
 export const nodeTypes: NodeTypes = {
@@ -36,6 +37,7 @@ export const nodeTypes: NodeTypes = {
   pythonNode: PythonNode,
   dataTransformNode: DataTransformNode,
   clusterNode: ClusterNode,
+  groupNode: GroupNode,
 } as const
 
 export {
@@ -56,5 +58,6 @@ export {
   ParameterNode,
   PythonNode,
   ClusterNode,
+  GroupNode,
 }
 

--- a/components/nodes/node-types.ts
+++ b/components/nodes/node-types.ts
@@ -185,4 +185,9 @@ export interface WatchNodeData extends BaseNodeData {
         watchType?: string;
         [key: string]: any;
     };
-} 
+}
+
+// Group node data
+export interface GroupNodeData extends BaseNodeData {
+    backgroundColor?: string;
+}

--- a/lib/keyboard-shortcuts.ts
+++ b/lib/keyboard-shortcuts.ts
@@ -123,6 +123,14 @@ export function getDefaultShortcuts(): KeyboardShortcut[] {
       action: () => {},
     },
     {
+      id: "group",
+      name: "Group Nodes",
+      description: "Group selected nodes",
+      keys: `${mod}+g`,
+      category: "edit",
+      action: () => {},
+    },
+    {
       id: "delete",
       name: "Delete",
       description: "Delete selected nodes",
@@ -166,7 +174,7 @@ export function getDefaultShortcuts(): KeyboardShortcut[] {
       id: "toggle-grid",
       name: "Toggle Grid",
       description: "Toggle grid visibility",
-      keys: `${mod}+g`,
+      keys: `${mod}+shift+g`,
       category: "view",
       action: () => {},
     },


### PR DESCRIPTION
## Summary
- add GroupNode component with editable label and configurable background
- enable grouping of selected nodes via Ctrl/Cmd+G and edit menu
- register group nodes and adjust keyboard shortcuts for grid toggle

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689d02ec41148320ac9dcd959734d891