### PR TITLE
feat: add node grouping

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -356,6 +356,16 @@ function FlowWithProvider() {
     { enableOnFormTags: false }
   );
 
+  // Group selected (Ctrl+G)
+  useHotkeys(
+    findShortcut("group-nodes") || "ctrl+g,cmd+g",
+    (e) => {
+      e.preventDefault();
+      handleGroup();
+    },
+    { enableOnFormTags: false }
+  );
+
   // Run Workflow (F5)
   useHotkeys(
     findShortcut("run-workflow") || "F5",
@@ -478,6 +488,58 @@ function FlowWithProvider() {
     handleCopy();
     handleDelete();
   }, [handleCopy, handleDelete]);
+
+  // Handle group
+  const handleGroup = useCallback(() => {
+    if (!reactFlowInstance) return;
+
+    const selected = nodes.filter((n) => n.selected && n.type !== 'groupNode');
+    if (selected.length === 0) return;
+
+    saveToHistory(nodes, edges);
+
+    const padding = 40;
+    const minX = Math.min(...selected.map((n) => n.position.x));
+    const minY = Math.min(...selected.map((n) => n.position.y));
+    const maxX = Math.max(
+      ...selected.map((n) => n.position.x + (n.width || 0)),
+    );
+    const maxY = Math.max(
+      ...selected.map((n) => n.position.y + (n.height || 0)),
+    );
+
+    const groupId = `group-${Date.now()}`;
+    const groupPosition = { x: minX - padding / 2, y: minY - padding / 2 };
+    const groupNode = {
+      id: groupId,
+      type: 'groupNode' as const,
+      position: groupPosition,
+      data: { label: 'Group', color: '#f3f4f6' },
+      style: { width: maxX - minX + padding, height: maxY - minY + padding },
+      selectable: true,
+      draggable: true,
+      connectable: false,
+      selected: true,
+    };
+
+    const updatedNodes = nodes.map((n) => {
+      if (selected.find((s) => s.id === n.id)) {
+        return {
+          ...n,
+          position: {
+            x: n.position.x - groupPosition.x,
+            y: n.position.y - groupPosition.y,
+          },
+          parentNode: groupId,
+          extent: 'parent',
+          selected: false,
+        };
+      }
+      return n;
+    });
+
+    setNodes([...updatedNodes, groupNode]);
+  }, [reactFlowInstance, nodes, edges, saveToHistory, setNodes]);
 
   // Handle paste
   const handlePaste = useCallback(() => {
@@ -1183,6 +1245,7 @@ function FlowWithProvider() {
           onCut={handleCut}
           onPaste={handlePaste}
           onDelete={handleDelete}
+          onGroup={handleGroup}
           onToggleSidebar={handleSidebarToggle}
           sidebarOpen={sidebarOpen}
         />

--- a/components/menubar.tsx
+++ b/components/menubar.tsx
@@ -58,6 +58,7 @@ interface AppMenubarProps {
   onCut: () => void;
   onPaste: () => void;
   onDelete: () => void;
+  onGroup: () => void;
   onToggleSidebar: () => void;
   sidebarOpen?: boolean;
 }
@@ -85,6 +86,7 @@ export function AppMenubar({
   onCut,
   onPaste,
   onDelete,
+  onGroup,
   onToggleSidebar,
   sidebarOpen = false,
 }: AppMenubarProps) {
@@ -311,6 +313,10 @@ export function AppMenubar({
           <MenubarItem onClick={onPaste}>
             Paste
             <MenubarShortcut>{getShortcutDisplay("paste")}</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem onClick={onGroup}>
+            Group Selected
+            <MenubarShortcut>{getShortcutDisplay("group-nodes")}</MenubarShortcut>
           </MenubarItem>
           <MenubarSeparator />
           <MenubarItem onClick={onSelectAll}>

--- a/components/nodes/group-node.tsx
+++ b/components/nodes/group-node.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useCallback } from "react";
+import { NodeProps, useReactFlow } from "reactflow";
+import type { GroupNodeData } from "./node-types";
+
+export function GroupNode({ id, data }: NodeProps<GroupNodeData>) {
+  const { setNodes } = useReactFlow();
+
+  const onLabelChange = useCallback(
+    (evt: React.ChangeEvent<HTMLInputElement>) => {
+      const value = evt.target.value;
+      setNodes((nds) =>
+        nds.map((node) =>
+          node.id === id ? { ...node, data: { ...node.data, label: value } } : node,
+        ),
+      );
+    },
+    [id, setNodes],
+  );
+
+  const onColorChange = useCallback(
+    (evt: React.ChangeEvent<HTMLInputElement>) => {
+      const value = evt.target.value;
+      setNodes((nds) =>
+        nds.map((node) =>
+          node.id === id ? { ...node, data: { ...node.data, color: value } } : node,
+        ),
+      );
+    },
+    [id, setNodes],
+  );
+
+  return (
+    <div
+      className="w-full h-full rounded-md border border-muted-foreground/50"
+      style={{ backgroundColor: data.color || "#f3f4f6" }}
+    >
+      <div className="flex items-center justify-between p-1 text-xs">
+        <input
+          className="bg-transparent outline-none w-full mr-1"
+          value={data.label}
+          onChange={onLabelChange}
+        />
+        <input type="color" value={data.color || "#f3f4f6"} onChange={onColorChange} />
+      </div>
+    </div>
+  );
+}
+
+export default GroupNode;
+

--- a/components/nodes/index.ts
+++ b/components/nodes/index.ts
@@ -16,6 +16,7 @@ import { ParameterNode } from "./parameter-node"
 import { PythonNode } from "./python-node"
 import { DataTransformNode } from "./data-transform-node"
 import { ClusterNode } from "./cluster-node"
+import { GroupNode } from "./group-node"
 
 // Define custom node types as a constant to prevent React Flow warning
 export const nodeTypes: NodeTypes = {
@@ -36,6 +37,7 @@ export const nodeTypes: NodeTypes = {
   pythonNode: PythonNode,
   dataTransformNode: DataTransformNode,
   clusterNode: ClusterNode,
+  groupNode: GroupNode,
 } as const
 
 export {
@@ -56,5 +58,6 @@ export {
   ParameterNode,
   PythonNode,
   ClusterNode,
+  GroupNode,
 }
 

--- a/components/nodes/node-types.ts
+++ b/components/nodes/node-types.ts
@@ -185,4 +185,12 @@ export interface WatchNodeData extends BaseNodeData {
         watchType?: string;
         [key: string]: any;
     };
-} 
+}
+
+// Group node data
+export interface GroupNodeData extends BaseNodeData {
+    color?: string;
+    properties?: {
+        [key: string]: any;
+    };
+}

--- a/lib/keyboard-shortcuts.ts
+++ b/lib/keyboard-shortcuts.ts
@@ -131,6 +131,14 @@ export function getDefaultShortcuts(): KeyboardShortcut[] {
       action: () => {},
     },
     {
+      id: "group-nodes",
+      name: "Group Selected",
+      description: "Group selected nodes",
+      keys: `${mod}+g`,
+      category: "edit",
+      action: () => {},
+    },
+    {
       id: "run-workflow",
       name: "Run Workflow",
       description: "Run the current workflow",
@@ -166,7 +174,7 @@ export function getDefaultShortcuts(): KeyboardShortcut[] {
       id: "toggle-grid",
       name: "Toggle Grid",
       description: "Toggle grid visibility",
-      keys: `${mod}+g`,
+      keys: `${mod}+shift+g`,
       category: "view",
       action: () => {},
     },


### PR DESCRIPTION
## Summary
- allow grouping selected nodes via Ctrl+G or edit menu
- add group node type with editable name and color
- shift grid toggle shortcut to Ctrl+Shift+G

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_689d02ec41148320ac9dcd959734d891