### PR TITLE
feat: add node grouping

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -346,6 +346,16 @@ function FlowWithProvider() {
     { enableOnFormTags: false }
   );
 
+  // Group (Ctrl+G)
+  useHotkeys(
+    findShortcut("group") || "ctrl+g,cmd+g",
+    (e) => {
+      e.preventDefault();
+      handleGroup();
+    },
+    { enableOnFormTags: false }
+  );
+
   // Delete (Delete key)
   useHotkeys(
     "delete,backspace",
@@ -529,6 +539,59 @@ function FlowWithProvider() {
       description: `${newNodes.length} node(s) and ${newEdges.length} connection(s) pasted`,
     });
   }, [clipboard, nodes, edges, saveToHistory, setNodes, setEdges, toast]);
+
+  // Handle grouping of selected nodes
+  const handleGroup = useCallback(() => {
+    const selected = nodes.filter((n) => n.selected);
+    if (selected.length === 0) return;
+
+    saveToHistory(nodes, edges);
+
+    const padding = 20;
+    const minX = Math.min(...selected.map((n) => n.position.x));
+    const minY = Math.min(...selected.map((n) => n.position.y));
+    const maxX = Math.max(
+      ...selected.map((n) => n.position.x + (n.width || 0))
+    );
+    const maxY = Math.max(
+      ...selected.map((n) => n.position.y + (n.height || 0))
+    );
+
+    const groupPosition = { x: minX - padding / 2, y: minY - padding / 2 };
+    const width = maxX - minX + padding;
+    const height = maxY - minY + padding;
+    const groupId = `group-${Date.now()}`;
+
+    const groupNode: Node = {
+      id: groupId,
+      type: "groupNode",
+      position: groupPosition,
+      style: { width, height },
+      data: { label: "Group", backgroundColor: "rgba(0,0,0,0.05)" },
+      selected: true,
+    };
+
+    const selectedIds = selected.map((n) => n.id);
+
+    setNodes((nds) => {
+      const updated = nds.map((n) => {
+        if (selectedIds.includes(n.id)) {
+          return {
+            ...n,
+            position: {
+              x: n.position.x - groupPosition.x,
+              y: n.position.y - groupPosition.y,
+            },
+            parentNode: groupId,
+            extent: "parent" as const,
+            selected: false,
+          };
+        }
+        return n;
+      });
+      return [...updated, groupNode];
+    });
+  }, [nodes, edges, saveToHistory, setNodes]);
 
   // Updated node changes handler with history
   const handleNodesChange = useCallback(
@@ -1182,6 +1245,7 @@ function FlowWithProvider() {
           onCopy={handleCopy}
           onCut={handleCut}
           onPaste={handlePaste}
+          onGroup={handleGroup}
           onDelete={handleDelete}
           onToggleSidebar={handleSidebarToggle}
           sidebarOpen={sidebarOpen}

--- a/components/menubar.tsx
+++ b/components/menubar.tsx
@@ -58,6 +58,7 @@ interface AppMenubarProps {
   onCut: () => void;
   onPaste: () => void;
   onDelete: () => void;
+  onGroup: () => void;
   onToggleSidebar: () => void;
   sidebarOpen?: boolean;
 }
@@ -85,6 +86,7 @@ export function AppMenubar({
   onCut,
   onPaste,
   onDelete,
+  onGroup,
   onToggleSidebar,
   sidebarOpen = false,
 }: AppMenubarProps) {
@@ -311,6 +313,10 @@ export function AppMenubar({
           <MenubarItem onClick={onPaste}>
             Paste
             <MenubarShortcut>{getShortcutDisplay("paste")}</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem onClick={onGroup}>
+            Group
+            <MenubarShortcut>{getShortcutDisplay("group")}</MenubarShortcut>
           </MenubarItem>
           <MenubarSeparator />
           <MenubarItem onClick={onSelectAll}>

--- a/components/nodes/group-node.tsx
+++ b/components/nodes/group-node.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { memo } from "react";
+import { NodeProps, useReactFlow } from "reactflow";
+import type { GroupNodeData } from "./node-types";
+
+export const GroupNode = memo(({ id, data }: NodeProps<GroupNodeData>) => {
+  const { setNodes } = useReactFlow();
+
+  const onLabelChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setNodes((nodes) =>
+      nodes.map((node) =>
+        node.id === id ? { ...node, data: { ...node.data, label: value } } : node
+      )
+    );
+  };
+
+  const onColorChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setNodes((nodes) =>
+      nodes.map((node) =>
+        node.id === id
+          ? { ...node, data: { ...node.data, backgroundColor: value } }
+          : node
+      )
+    );
+  };
+
+  return (
+    <div
+      className="w-full h-full rounded border-2 border-blue-300 relative"
+      style={{ backgroundColor: data.backgroundColor || "rgba(0,0,0,0.05)" }}
+    >
+      <div className="absolute top-1 left-1 flex items-center gap-1">
+        <input
+          value={data.label}
+          onChange={onLabelChange}
+          className="bg-transparent text-xs font-medium outline-none"
+        />
+        <input
+          type="color"
+          value={data.backgroundColor || "#f3f4f6"}
+          onChange={onColorChange}
+          className="w-4 h-4 p-0 border-none"
+        />
+      </div>
+    </div>
+  );
+});
+
+GroupNode.displayName = "GroupNode";

--- a/components/nodes/index.ts
+++ b/components/nodes/index.ts
@@ -16,6 +16,7 @@ import { ParameterNode } from "./parameter-node"
 import { PythonNode } from "./python-node"
 import { DataTransformNode } from "./data-transform-node"
 import { ClusterNode } from "./cluster-node"
+import { GroupNode } from "./group-node"
 
 // Define custom node types as a constant to prevent React Flow warning
 export const nodeTypes: NodeTypes = {
@@ -36,6 +37,7 @@ export const nodeTypes: NodeTypes = {
   pythonNode: PythonNode,
   dataTransformNode: DataTransformNode,
   clusterNode: ClusterNode,
+  groupNode: GroupNode,
 } as const
 
 export {
@@ -56,5 +58,6 @@ export {
   ParameterNode,
   PythonNode,
   ClusterNode,
+  GroupNode,
 }
 

--- a/components/nodes/node-types.ts
+++ b/components/nodes/node-types.ts
@@ -185,4 +185,9 @@ export interface WatchNodeData extends BaseNodeData {
         watchType?: string;
         [key: string]: any;
     };
-} 
+}
+
+// Group node data
+export interface GroupNodeData extends BaseNodeData {
+    backgroundColor?: string;
+}

--- a/lib/keyboard-shortcuts.ts
+++ b/lib/keyboard-shortcuts.ts
@@ -123,6 +123,14 @@ export function getDefaultShortcuts(): KeyboardShortcut[] {
       action: () => {},
     },
     {
+      id: "group",
+      name: "Group Nodes",
+      description: "Group selected nodes",
+      keys: `${mod}+g`,
+      category: "edit",
+      action: () => {},
+    },
+    {
       id: "delete",
       name: "Delete",
       description: "Delete selected nodes",
@@ -166,7 +174,7 @@ export function getDefaultShortcuts(): KeyboardShortcut[] {
       id: "toggle-grid",
       name: "Toggle Grid",
       description: "Toggle grid visibility",
-      keys: `${mod}+g`,
+      keys: `${mod}+shift+g`,
       category: "view",
       action: () => {},
     },


### PR DESCRIPTION
## Summary
- allow grouping selected nodes with new GroupNode type
- add Edit→Group menu entry and Ctrl+G shortcut
- update keyboard shortcuts and grid toggle

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: interactive prompt)
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689d02ec41148320ac9dcd959734d891