### PR TITLE
Split ifc utils by responsibility

### DIFF
--- a/lib/ifc/state.ts
+++ b/lib/ifc/state.ts
@@ -1,0 +1,76 @@
+import type { IfcModel } from "./types";
+
+// Global reference to the last loaded model
+let _lastLoadedModel: IfcModel | null = null;
+
+// Cache for storing the original File objects of loaded IFC files
+const ifcFileCache: Map<string, File> = new Map();
+
+export function cacheIfcFile(file: File) {
+  if (file && file.name) {
+    if (!ifcFileCache.has(file.name)) {
+      ifcFileCache.set(file.name, file);
+      console.log(`Cached File object: ${file.name}`);
+    }
+  } else {
+    console.warn("Attempted to cache an invalid File object.");
+  }
+}
+
+export function getIfcFile(fileName: string): File | null {
+  return ifcFileCache.get(fileName) || null;
+}
+
+export function getLastLoadedModel(): IfcModel | null {
+  console.log("🔍 Getting last loaded model:", {
+    hasModel: !!_lastLoadedModel,
+    modelId: _lastLoadedModel?.id,
+    modelName: _lastLoadedModel?.name,
+    elementCount: _lastLoadedModel?.elements?.length,
+  });
+  return _lastLoadedModel;
+}
+
+export function setLastLoadedModel(model: IfcModel | null): void {
+  _lastLoadedModel = model;
+  console.log("📝 Set last loaded model:", {
+    hasModel: !!model,
+    modelId: model?.id,
+    modelName: model?.name,
+    elementCount: model?.elements?.length,
+  });
+}
+
+export function getModelPropertyNames(model?: IfcModel): string[] {
+  const current = model || getLastLoadedModel();
+  if (!current) return [];
+
+  const props = new Set<string>();
+
+  current.elements.forEach((el) => {
+    if (el.properties) {
+      Object.keys(el.properties).forEach((p) => props.add(p));
+    }
+    if (el.psets) {
+      for (const pset in el.psets) {
+        const psetProps = el.psets[pset];
+        for (const prop in psetProps) {
+          props.add(`${pset}.${prop}`);
+        }
+      }
+    }
+  });
+
+  return Array.from(props).sort();
+}
+
+// Expose internal cache for modules needing raw access (avoid exporting the map)
+export const __stateInternals = {
+  get cache() {
+    return ifcFileCache;
+  },
+  get lastModel() {
+    return _lastLoadedModel;
+  },
+};
+

--- a/lib/ifc/types.ts
+++ b/lib/ifc/types.ts
@@ -1,0 +1,83 @@
+// Core IFC types and worker message/result types
+
+export interface IfcElement {
+  id: string;
+  expressId: number;
+  type: string;
+  properties: Record<string, any>;
+  geometry?: any;
+  psets?: Record<string, any>;
+  qtos?: Record<string, any>;
+  propertyInfo?: {
+    name: string;
+    exists: boolean;
+    value: any;
+    psetName: string;
+  };
+  classifications?: Array<{
+    System: string;
+    Code: string;
+    Description: string;
+  }>;
+  transformedGeometry?: {
+    translation: [number, number, number];
+    rotation: [number, number, number];
+    scale: [number, number, number];
+  };
+}
+
+export interface IfcModel {
+  id: string;
+  name: string;
+  file?: any;
+  schema?: string;
+  project?: {
+    GlobalId: string;
+    Name: string;
+    Description: string;
+  };
+  elementCounts?: Record<string, number>;
+  totalElements?: number;
+  elements: IfcElement[];
+  sqliteDb?: string;
+  sqliteSuccess?: boolean;
+}
+
+export interface QuantityResults {
+  groups: Record<string, number>;
+  unit: string;
+  total: number;
+  groupBy?: string;
+  error?: string;
+}
+
+export interface PropertyActions {
+  action: string;
+  propertyName: string;
+  propertyValue?: any;
+  targetPset?: string;
+}
+
+export type ProgressHandler = (progress: number, message?: string) => void;
+
+// Worker request/response plumbing
+export interface WorkerRequest<T = any> {
+  action: string;
+  messageId: string;
+  data?: T;
+}
+
+export interface WorkerResponse<T = any> {
+  type: string;
+  messageId?: string;
+  error?: string;
+  data?: T;
+  [key: string]: any;
+}
+
+export interface RequestOptions {
+  timeoutMs?: number;
+  transfer?: (ArrayBuffer | MessagePort | ImageBitmap)[];
+  onProgress?: ProgressHandler;
+}
+


### PR DESCRIPTION
Initial split of `lib/ifc-utils.ts` into `lib/ifc/types.ts` and `lib/ifc/state.ts` to improve module organization.

---
<a href="https://cursor.com/background-agent?bcId=bc-1cc6dcfa-446d-43a4-af6c-c1d9826d30ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1cc6dcfa-446d-43a4-af6c-c1d9826d30ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

